### PR TITLE
fix: kots-sdk reports different app versions during an upgrade

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -53,7 +53,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 License Fields
 */}}
-{{- define "licenseFields" -}}
+{{- define "kots-sdk.licenseFields" -}}
 {{- if .Values.global -}}
 {{- if .Values.global.licenseFields -}}
 {{- .Values.global.licenseFields | toYaml -}}

--- a/chart/templates/kots-sdk-deployment.yaml
+++ b/chart/templates/kots-sdk-deployment.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: kots-sdk
-  strategy: {}
+      {{- include "kots-sdk.selectorLabels" . | nindent 6 }}
+  strategy:
+    # this is to avoid having two sdk instances reporting at the same time for different app versions.
+    type: Recreate
   template:
     metadata:
       labels:
-        app: kots-sdk
         {{- include "kots-sdk.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -27,7 +28,7 @@ spec:
         - name: KOTS_SDK_LICENSE_BASE64
           value: {{ .Values.license | b64enc }}
         - name: KOTS_SDK_LICENSE_FIELDS_BASE64
-          value: {{ include "licenseFields" . | b64enc }}
+          value: {{ include "kots-sdk.licenseFields" . | b64enc }}
         - name: KOTS_SDK_CHANNEL_ID
           value: {{ .Values.channelID }}
         - name: KOTS_SDK_CHANNEL_NAME
@@ -39,7 +40,7 @@ spec:
         - name: KOTS_SDK_VERSION_LABEL
           value: "{{ .Values.versionLabel }}"
         - name: KOTS_SDK_INFORMERS_LABEL_SELECTOR
-          value: "app.kubernetes.io/managed-by=Helm,app.kubernetes.io/instance={{ .Release.Name }}"
+          value: "app.kubernetes.io/managed-by={{ .Release.Service }},app.kubernetes.io/name!={{ include "kots-sdk.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
         - name: KOTS_SDK_NAMESPACE
           valueFrom:
             fieldRef:

--- a/chart/templates/kots-sdk-service.yaml
+++ b/chart/templates/kots-sdk-service.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   labels:
     {{- include "kots-sdk.labels" . | nindent 4 }}
-  name: {{ include "kots-sdk.fullname" . }}
+  name: kots-sdk
 spec:
   ports:
   - name: http
     port: {{ .Values.service.port }}
     targetPort: 3000
   selector:
-    app: kots-sdk
+    {{- include "kots-sdk.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}


### PR DESCRIPTION
During a rolling upgrade, the old kots-sdk pod will be running until the new one comes up, which means that two instances of the sdk will be reporting at the same time but for different app versions/info.

This PR:

- Changes the kots-sdk deployment strategy to `Recreate` so that the old pod is terminated before the new one comes up and starts reporting.
- Excludes the kots-sdk resources from the reporting data.