### PR TITLE
use `Replicated-SDK` as user-agent header's product prefix

### DIFF
--- a/cmd/replicated/version.go
+++ b/cmd/replicated/version.go
@@ -46,7 +46,7 @@ func VersionCmd() *cobra.Command {
 			}
 
 			// print basic version info
-			fmt.Printf("Replicated %s\n", buildversion.Version())
+			fmt.Printf("Replicated SDK %s\n", buildversion.Version())
 
 			return nil
 		},

--- a/pkg/buildversion/buildversion.go
+++ b/pkg/buildversion/buildversion.go
@@ -76,5 +76,5 @@ func getGoInfo() GoInfo {
 }
 
 func GetUserAgent() string {
-	return fmt.Sprintf("Replicated/%s", Version())
+	return fmt.Sprintf("Replicated-SDK/%s", Version())
 }


### PR DESCRIPTION
- use `Replicated-SDK` as user-agent header's product prefix
- update `replicated version` to return prefix as `Replicated SDK`
```
➜  bin/replicated version 
Replicated SDK alpha
```