### PR TITLE
remove unneeded fields from license and app api responses

### DIFF
--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -34,8 +34,6 @@ type AppRelease struct {
 	VersionLabel         string `json:"versionLabel"`
 	ChannelID            string `json:"channelID"`
 	ChannelName          string `json:"channelName"`
-	ChannelSequence      int64  `json:"channelSequence"`
-	ReleaseSequence      int64  `json:"releaseSequence"`
 	IsRequired           bool   `json:"isRequired"`
 	CreatedAt            string `json:"createdAt"`
 	ReleaseNotes         string `json:"releaseNotes"`
@@ -53,8 +51,6 @@ func GetCurrentAppInfo(w http.ResponseWriter, r *http.Request) {
 			VersionLabel:         store.GetStore().GetVersionLabel(),
 			ChannelID:            store.GetStore().GetChannelID(),
 			ChannelName:          store.GetStore().GetChannelName(),
-			ChannelSequence:      store.GetStore().GetChannelSequence(),
-			ReleaseSequence:      store.GetStore().GetReleaseSequence(),
 			IsRequired:           store.GetStore().GetReleaseIsRequired(),
 			CreatedAt:            store.GetStore().GetReleaseCreatedAt(),
 			ReleaseNotes:         store.GetStore().GetReleaseNotes(),
@@ -165,8 +161,6 @@ func helmReleaseToAppRelease(helmRelease *helmrelease.Release) *AppRelease {
 
 		appRelease.ChannelID = data["REPLICATED_CHANNEL_ID"].(string)
 		appRelease.ChannelName = data["REPLICATED_CHANNEL_NAME"].(string)
-		appRelease.ChannelSequence, _ = strconv.ParseInt(data["REPLICATED_CHANNEL_SEQUENCE"].(string), 10, 64)
-		appRelease.ReleaseSequence, _ = strconv.ParseInt(data["REPLICATED_RELEASE_SEQUENCE"].(string), 10, 64)
 		appRelease.IsRequired, _ = strconv.ParseBool(data["REPLICATED_RELEASE_IS_REQUIRED"].(string))
 		appRelease.CreatedAt = data["REPLICATED_RELEASE_CREATED_AT"].(string)
 		appRelease.ReleaseNotes = data["REPLICATED_RELEASE_NOTES"].(string)

--- a/pkg/handlers/license.go
+++ b/pkg/handlers/license.go
@@ -13,15 +13,12 @@ import (
 )
 
 type LicenseInfo struct {
-	LicenseID           string `json:"licenseID"`
-	ChannelID           string `json:"channelID"`
-	ChannelName         string `json:"channelName"`
-	CustomerName        string `json:"customerName"`
-	CustomerEmail       string `json:"customerEmail"`
-	LicenseType         string `json:"licenseType"`
-	IsAirgapSupported   bool   `json:"isAirgapSupported"`
-	IsGitOpsSupported   bool   `json:"isGitOpsSupported"`
-	IsSnapshotSupported bool   `json:"isSnapshotSupported"`
+	LicenseID     string `json:"licenseID"`
+	ChannelID     string `json:"channelID"`
+	ChannelName   string `json:"channelName"`
+	CustomerName  string `json:"customerName"`
+	CustomerEmail string `json:"customerEmail"`
+	LicenseType   string `json:"licenseType"`
 }
 
 func GetLicenseInfo(w http.ResponseWriter, r *http.Request) {
@@ -41,15 +38,12 @@ func GetLicenseInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	licenseInfo := LicenseInfo{
-		LicenseID:           license.Spec.LicenseID,
-		ChannelID:           license.Spec.ChannelID,
-		ChannelName:         license.Spec.ChannelName,
-		CustomerName:        license.Spec.CustomerName,
-		CustomerEmail:       license.Spec.CustomerEmail,
-		LicenseType:         license.Spec.LicenseType,
-		IsAirgapSupported:   license.Spec.IsAirgapSupported,
-		IsGitOpsSupported:   license.Spec.IsGitOpsSupported,
-		IsSnapshotSupported: license.Spec.IsSnapshotSupported,
+		LicenseID:     license.Spec.LicenseID,
+		ChannelID:     license.Spec.ChannelID,
+		ChannelName:   license.Spec.ChannelName,
+		CustomerName:  license.Spec.CustomerName,
+		CustomerEmail: license.Spec.CustomerEmail,
+		LicenseType:   license.Spec.LicenseType,
 	}
 
 	JSON(w, http.StatusOK, licenseInfo)

--- a/pkg/upstream/types/types.go
+++ b/pkg/upstream/types/types.go
@@ -14,10 +14,8 @@ func (rc1 ReplicatedCursor) Equal(rc2 ReplicatedCursor) bool {
 }
 
 type ChannelRelease struct {
-	ChannelSequence int    `json:"channelSequence"`
-	ReleaseSequence int    `json:"releaseSequence"`
-	VersionLabel    string `json:"versionLabel"`
-	IsRequired      bool   `json:"isRequired"`
-	CreatedAt       string `json:"createdAt"`
-	ReleaseNotes    string `json:"releaseNotes"`
+	VersionLabel string `json:"versionLabel"`
+	IsRequired   bool   `json:"isRequired"`
+	CreatedAt    string `json:"createdAt"`
+	ReleaseNotes string `json:"releaseNotes"`
 }


### PR DESCRIPTION
This PR removes some fields that are not needed to be included in api responses:
- removed `releaseSequence` and `channelSequence` from all three of the /api/v1/app/* APIs
- removed `isAirgapSupported`, `isGitOpsSupported`, and `isSnapshotSupported` from `/api/v1/license/info`