### PR TITLE
Use Chainguard Image for Replicated SDK

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,4 +48,4 @@ jobs:
           tags: ttl.sh/automated-${{ github.run_id }}/replicated-sdk:24h
           context: ./
           file: ./Dockerfile
-          push: true
+          push: false # we don't need to push the image since we don't have any e2e tests yet

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,3 +37,15 @@ jobs:
           go-version: '^1.20'
       - name: make build
         run: make build
+
+  build-and-push-ttl-image:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: build and push kotsadm for e2e
+        uses: docker/build-push-action@v3
+        with:
+          tags: ttl.sh/automated-${{ github.run_id }}/replicated-sdk:24h
+          context: ./
+          file: ./Dockerfile
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,7 @@ RUN make build && mv ./bin/replicated-sdk /replicated-sdk
 
 FROM cgr.dev/chainguard/static:latest
 
-USER replicated-sdk
-
-COPY --from=builder --chown=replicated-sdk:replicated-sdk /replicated-sdk /replicated-sdk
+COPY --from=builder /replicated-sdk /replicated-sdk
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go:1.20-dev as builder
+FROM cgr.dev/chainguard/go:1.20 as builder
 
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/replicated-sdk
 WORKDIR $PROJECTPATH
@@ -14,17 +14,9 @@ ENV GIT_TAG=${git_tag}
 
 RUN make build && mv ./bin/replicated-sdk /replicated-sdk
 
-FROM cgr.dev/chainguard/go:1.20-dev
+FROM cgr.dev/chainguard/static:latest
 
-ENTRYPOINT ["/bin/bash"]
-
-RUN apk update && apk add --no-cache --update-cache curl gnupg ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
-
-# Setup user
-RUN adduser -D -g 'replicated-sdk  user' -h /home/replicated-sdk  -s /bin/bash -u 1001 replicated-sdk 
-USER replicated-sdk 
-ENV HOME /home/replicated-sdk 
+USER replicated-sdk
 
 COPY --from=builder --chown=replicated-sdk:replicated-sdk /replicated-sdk /replicated-sdk
 


### PR DESCRIPTION
 ### Summary

These PR changes the Docker Image from the standard golang to use Chainguard's community golang image for the first build stage and Chainguard's static image for the final build stage.

### Why

- The current golang image on dockerhub contains 66 vulnerabilities and is 792MB.
- The Chainguard image image contains 0 vulnerabilities and is 652MB.
- Using Chainguard means we are using an image with fewer vulnerabilities and a smaller attack surface.
- Using the static image for the final build stage reduced the total image size from 894MB to 49.9MB

### Summary of Chages
- Use chainguard go:1.20 for first stage and chainguard static:latest for final stage
- Add a `build-and-push-ttl-image` to validate the image build on PR


