### PR TITLE
fix: reporting for apps without expected labels

### DIFF
--- a/pkg/appstate/types/types.go
+++ b/pkg/appstate/types/types.go
@@ -10,6 +10,8 @@ var (
 	StateDegraded    State = "degraded"
 	StateUnavailable State = "unavailable"
 	StateMissing     State = "missing"
+	StateUnknown     State = "unknown"
+	StateNone        State = "none"
 )
 
 type AppInformersArgs struct {
@@ -39,7 +41,7 @@ type State string
 
 func GetState(resourceStates []ResourceState) State {
 	if len(resourceStates) == 0 {
-		return StateMissing
+		return StateUnknown
 	}
 	max := StateReady
 	for _, resourceState := range resourceStates {
@@ -50,7 +52,7 @@ func GetState(resourceStates []ResourceState) State {
 
 func MinState(ss ...State) (min State) {
 	if len(ss) == 0 {
-		return StateMissing
+		return StateUnknown
 	}
 	for _, s := range ss {
 		if s == StateMissing || min == StateMissing {

--- a/pkg/appstate/types/types_test.go
+++ b/pkg/appstate/types/types_test.go
@@ -38,13 +38,160 @@ func TestMinState(t *testing.T) {
 		{
 			name: "none",
 			ss:   []State{},
-			want: StateMissing,
+			want: StateUnknown,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := MinState(tt.ss...); got != tt.want {
 				t.Errorf("MinState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetState(t *testing.T) {
+	tests := []struct {
+		name           string
+		resourceStates []ResourceState
+		want           State
+	}{
+		{
+			name: "ready",
+			resourceStates: []ResourceState{
+				{
+					Kind:      "Deployment",
+					Name:      "ready-1",
+					Namespace: "default",
+					State:     StateReady,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "ready-2",
+					Namespace: "default",
+					State:     StateReady,
+				},
+			},
+			want: StateReady,
+		},
+		{
+			name: "updating",
+			resourceStates: []ResourceState{
+				{
+					Kind:      "Deployment",
+					Name:      "updating-1",
+					Namespace: "default",
+					State:     StateUpdating,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "ready-1",
+					Namespace: "default",
+					State:     StateReady,
+				},
+			},
+			want: StateUpdating,
+		},
+		{
+			name: "degraded",
+			resourceStates: []ResourceState{
+				{
+					Kind:      "Deployment",
+					Name:      "ready-1",
+					Namespace: "default",
+					State:     StateReady,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "degraded-1",
+					Namespace: "default",
+					State:     StateDegraded,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "updating-1",
+					Namespace: "default",
+					State:     StateUpdating,
+				},
+			},
+			want: StateDegraded,
+		},
+		{
+			name: "unavailable",
+			resourceStates: []ResourceState{
+				{
+					Kind:      "Deployment",
+					Name:      "ready-1",
+					Namespace: "default",
+					State:     StateReady,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "degraded-1",
+					Namespace: "default",
+					State:     StateDegraded,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "unavailable-1",
+					Namespace: "default",
+					State:     StateUnavailable,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "updating-1",
+					Namespace: "default",
+					State:     StateUpdating,
+				},
+			},
+			want: StateUnavailable,
+		},
+		{
+			name: "missing",
+			resourceStates: []ResourceState{
+				{
+					Kind:      "Deployment",
+					Name:      "ready-1",
+					Namespace: "default",
+					State:     StateReady,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "degraded-1",
+					Namespace: "default",
+					State:     StateDegraded,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "missing-1",
+					Namespace: "default",
+					State:     StateMissing,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "unavailable-1",
+					Namespace: "default",
+					State:     StateUnavailable,
+				},
+				{
+					Kind:      "Deployment",
+					Name:      "updating-1",
+					Namespace: "default",
+					State:     StateUpdating,
+				},
+			},
+			want: StateMissing,
+		},
+		{
+			name:           "none",
+			resourceStates: []ResourceState{},
+			want:           StateUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetState(tt.resourceStates); got != tt.want {
+				t.Errorf("GetState() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -203,10 +203,11 @@ func (s *Store) GetNamespace() string {
 
 func (s *Store) GetAppStatus() appstatetypes.AppStatus {
 	if s.appStatus.State == "" {
+		// initialize with none state so that subsequent changes will trigger reporting
 		return appstatetypes.AppStatus{
 			AppSlug:  s.appSlug,
 			Sequence: s.releaseSequence,
-			State:    appstatetypes.StateMissing,
+			State:    appstatetypes.StateNone,
 		}
 	}
 	return s.appStatus


### PR DESCRIPTION
Fixes: [SC-79718](https://app.shortcut.com/replicated/story/79718/insights-reporting-visibility-for-running-sdk-instance-without-required-labels)

This PR introduces two new app states `None` and `Unknown`.  `None` is the initialized state for the SDK before and resource states are queried.  Once a state is determined, the store will be updated and the change will be reported.  If there are not any resources with the expected labels matching the selector, a state of `Unknown` will be set.

Example where a chart was deployed without these labels and gets an `Unknown` status.  Then labels were added and a new version was deployed (0.3.0) and the status then reported as `Ready`.

![Screen Shot 2023-06-14 at 4 56 38 PM](https://github.com/replicatedhq/replicated-sdk/assets/17422963/c133f3b8-4352-4c9d-bac3-606bf6fe63d2)
