### PR TITLE
add default-http-backend ingress service when k8s version is < 1.22

### DIFF
--- a/pkg/appstate/ingress.go
+++ b/pkg/appstate/ingress.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/replicatedhq/replicated-sdk/pkg/appstate/types"
 	"github.com/replicatedhq/replicated-sdk/pkg/k8sutil"
+	"github.com/replicatedhq/replicated-sdk/pkg/logger"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -120,7 +121,9 @@ func CalculateIngressState(clientset kubernetes.Interface, r *networkingv1.Ingre
 	backend := r.Spec.DefaultBackend
 
 	k8sMinorVersion, err := k8sutil.GetK8sMinorVersion(clientset)
-	if err == nil && k8sMinorVersion < 22 && backend == nil {
+	if err != nil {
+		logger.Errorf("failed to get k8s minor version: %v", err)
+	} else if k8sMinorVersion < 22 && backend == nil {
 		// https://github.com/kubernetes/kubectl/blob/6b77b0790ab40d2a692ad80e9e4c962e784bb9b8/pkg/describe/versioned/describe.go#L2367
 		// Ingresses that don't specify a default backend inherit the default backend in the kube-system namespace.
 		// This behavior is applicable to Kubernetes versions prior to 1.22 (i.e. Ingress versions before networking.k8s.io/v1).

--- a/pkg/appstate/ingress.go
+++ b/pkg/appstate/ingress.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/replicatedhq/replicated-sdk/pkg/appstate/types"
+	"github.com/replicatedhq/replicated-sdk/pkg/k8sutil"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -115,13 +116,14 @@ func makeIngressResourceState(r *networkingv1.Ingress, state types.State) types.
 }
 
 func CalculateIngressState(clientset kubernetes.Interface, r *networkingv1.Ingress) types.State {
-	var states []types.State
-	// https://github.com/kubernetes/kubectl/blob/6b77b0790ab40d2a692ad80e9e4c962e784bb9b8/pkg/describe/versioned/describe.go#L2367
-	backend := r.Spec.DefaultBackend
 	ns := r.Namespace
-	if backend == nil {
-		// Ingresses that don't specify a default backend inherit the
-		// default backend in the kube-system namespace.
+	backend := r.Spec.DefaultBackend
+
+	k8sMinorVersion, err := k8sutil.GetK8sMinorVersion(clientset)
+	if err == nil && k8sMinorVersion < 22 && backend == nil {
+		// https://github.com/kubernetes/kubectl/blob/6b77b0790ab40d2a692ad80e9e4c962e784bb9b8/pkg/describe/versioned/describe.go#L2367
+		// Ingresses that don't specify a default backend inherit the default backend in the kube-system namespace.
+		// This behavior is applicable to Kubernetes versions prior to 1.22 (i.e. Ingress versions before networking.k8s.io/v1).
 		backend = &networkingv1.IngressBackend{
 			Service: &networkingv1.IngressServiceBackend{
 				Name: "default-http-backend",
@@ -132,7 +134,12 @@ func CalculateIngressState(clientset kubernetes.Interface, r *networkingv1.Ingre
 		}
 		ns = metav1.NamespaceSystem
 	}
-	states = append(states, ingressGetStateFromBackend(clientset, ns, *backend))
+
+	var states []types.State
+	if backend != nil {
+		states = append(states, ingressGetStateFromBackend(clientset, ns, *backend))
+	}
+
 	for _, rules := range r.Spec.Rules {
 		for _, path := range rules.HTTP.Paths {
 			states = append(states, ingressGetStateFromBackend(clientset, r.Namespace, path.Backend))

--- a/pkg/appstate/ingress_test.go
+++ b/pkg/appstate/ingress_test.go
@@ -1,0 +1,61 @@
+package appstate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/replicatedhq/replicated-sdk/pkg/appstate/types"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/version"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func mockClientsetK8sVersion(expectedMajor string, expectedMinor string) kubernetes.Interface {
+	clientset := fake.NewSimpleClientset()
+	clientset.Discovery().(*discoveryfake.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major: expectedMajor,
+		Minor: expectedMinor,
+	}
+	return clientset
+}
+
+func TestCalculateIngressState(t *testing.T) {
+	type args struct {
+		clientset kubernetes.Interface
+		r         *networkingv1.Ingress
+	}
+	tests := []struct {
+		name string
+		args args
+		want types.State
+	}{
+		{
+			name: "ingress with k8s version < 1.22 and no default backend",
+			args: args{
+				clientset: mockClientsetK8sVersion("1", "21"),
+				r: &networkingv1.Ingress{
+					Spec: networkingv1.IngressSpec{},
+				},
+			},
+			want: types.StateUnavailable,
+		}, {
+			name: "ingress with k8s version > 1.22 and default backend",
+			args: args{
+				clientset: mockClientsetK8sVersion("1", "23"),
+				r: &networkingv1.Ingress{
+					Spec: networkingv1.IngressSpec{},
+				},
+			},
+			want: types.StateUnavailable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalculateIngressState(tt.args.clientset, tt.args.r); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CalculateIngressState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/appstate/ingress_test.go
+++ b/pkg/appstate/ingress_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/replicatedhq/replicated-sdk/pkg/appstate/types"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	discoveryfake "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes"
@@ -13,7 +15,44 @@ import (
 )
 
 func mockClientsetK8sVersion(expectedMajor string, expectedMinor string) kubernetes.Interface {
-	clientset := fake.NewSimpleClientset()
+	clientset := fake.NewSimpleClientset(
+		// add a service
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-http-backend",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Spec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{
+					{
+						Name: "http",
+						Port: 80,
+					},
+				},
+			},
+		},
+		&v1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-http-backend",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Subsets: []v1.EndpointSubset{
+				{
+					Ports: []v1.EndpointPort{
+						{
+							Name: "http",
+							Port: 80,
+						},
+					},
+					Addresses: []v1.EndpointAddress{
+						{
+							IP: "192.0.0.2",
+						},
+					},
+				},
+			},
+		},
+	)
 	clientset.Discovery().(*discoveryfake.FakeDiscovery).FakedServerVersion = &version.Info{
 		Major: expectedMajor,
 		Minor: expectedMinor,
@@ -32,16 +71,26 @@ func TestCalculateIngressState(t *testing.T) {
 		want types.State
 	}{
 		{
-			name: "ingress with k8s version < 1.22 and no default backend",
+			name: "expect ready state when ingress with k8s version < 1.22 and no default backend",
 			args: args{
 				clientset: mockClientsetK8sVersion("1", "21"),
 				r: &networkingv1.Ingress{
 					Spec: networkingv1.IngressSpec{},
+					Status: networkingv1.IngressStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{
+								{
+									IP: "192.0.0.1",
+								},
+							},
+						},
+					},
 				},
 			},
-			want: types.StateUnavailable,
-		}, {
-			name: "ingress with k8s version > 1.22 and default backend",
+			want: types.StateReady,
+		},
+		{
+			name: "expect unavailable state when ingress with k8s version > 1.22 and no default backend",
 			args: args{
 				clientset: mockClientsetK8sVersion("1", "23"),
 				r: &networkingv1.Ingress{
@@ -49,6 +98,24 @@ func TestCalculateIngressState(t *testing.T) {
 				},
 			},
 			want: types.StateUnavailable,
+		}, {
+			name: "expect ready state when ingress with k8s version > 1.22 and no default backend and with load balancer status",
+			args: args{
+				clientset: mockClientsetK8sVersion("1", "23"),
+				r: &networkingv1.Ingress{
+					Spec: networkingv1.IngressSpec{},
+					Status: networkingv1.IngressStatus{
+						LoadBalancer: v1.LoadBalancerStatus{
+							Ingress: []v1.LoadBalancerIngress{
+								{
+									IP: "192.0.0.1",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: types.StateReady,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8sutil/clientset.go
+++ b/pkg/k8sutil/clientset.go
@@ -1,6 +1,8 @@
 package k8sutil
 
 import (
+	"strconv"
+
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -70,4 +72,17 @@ func GetK8sVersion() (string, error) {
 		return "", errors.Wrap(err, "failed to get kubernetes server version")
 	}
 	return k8sVersion.GitVersion, nil
+}
+
+func GetK8sMinorVersion(clientset kubernetes.Interface) (int, error) {
+	k8sVersion, err := clientset.Discovery().ServerVersion()
+	if err != nil {
+		return -1, errors.Wrap(err, "failed to get kubernetes server version")
+	}
+
+	k8sMinorVersion, err := strconv.Atoi(k8sVersion.Minor)
+	if err != nil {
+		return -1, errors.Wrap(err, "failed to convert k8s minor version to int")
+	}
+	return k8sMinorVersion, nil
 }

--- a/pkg/k8sutil/clientset_test.go
+++ b/pkg/k8sutil/clientset_test.go
@@ -1,0 +1,47 @@
+package k8sutil
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/version"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func mockClientsetK8sVersion(expectedMajor string, expectedMinor string) kubernetes.Interface {
+	clientset := fake.NewSimpleClientset()
+	clientset.Discovery().(*discoveryfake.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major: expectedMajor,
+		Minor: expectedMinor,
+	}
+	return clientset
+}
+
+func TestGetK8sMinorVersion(t *testing.T) {
+	type args struct {
+		clientset kubernetes.Interface
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{"expect minor version 22", args{mockClientsetK8sVersion("1", "22")}, 22, false},
+		{"expect minor version 21", args{mockClientsetK8sVersion("1", "21")}, 21, false},
+		{"expect minor version conversion error", args{mockClientsetK8sVersion("1", "a")}, -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetK8sMinorVersion(tt.args.clientset)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetK8sMinorVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetK8sMinorVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
add default-http-backend ingress service when k8s version is < 1.22
Fixes # https://app.shortcut.com/replicated/story/81855/app-status-not-showing-deployed-application-as-ready-even-if-the-app-is-running