### PR TITLE
feat: Add support bundle secret to for collecting logs

### DIFF
--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -21,4 +21,4 @@ stringData:
             collectorName: replicated-logs
             selector:
               {{- include "replicated.labels" . | nindent 14 }}
-            name: replicated-sdk/logs
+            name: replicated/logs


### PR DESCRIPTION
Fixes [82444](https://app.shortcut.com/replicated/story/82444/add-support-bundle-spec-in-the-replicated-sdk-chart)

We will initially just collect logs but we can extend the specs to collect configuration options and other non-sensitive data from a cluster

This is how, once templated out, the spec would look like

```yaml
apiVersion: v1
kind: Secret
metadata:
  labels:
    helm.sh/chart: replicated-0.0.1-alpha.19
    app.kubernetes.io/name: replicated
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.0.1-alpha.19"
    app.kubernetes.io/managed-by: Helm
  name: replicated-sdk-supportbundle
stringData:
  support-bundle-spec: |-
    apiVersion: troubleshoot.sh/v1beta2
    kind: SupportBundle
    metadata:
      name: replicated-sdk-supportbundle
    spec:
      collectors:
        - logs:
            collectorName: replicated-sdk-logs
            selector:
              helm.sh/chart: replicated-0.0.1-alpha.19
              app.kubernetes.io/name: replicated
              app.kubernetes.io/instance: release-name
              app.kubernetes.io/version: "v0.0.1-alpha.19"
              app.kubernetes.io/managed-by: Helm
            name: replicated-sdk/logs
```