### PR TITLE
read channel info from license

### DIFF
--- a/cmd/replicated/api.go
+++ b/cmd/replicated/api.go
@@ -72,12 +72,22 @@ func APICmd() *cobra.Command {
 				}
 			}
 
+			channelID := replicatedConfig.ChannelID
+			if channelID == "" {
+				channelID = license.Spec.ChannelID
+			}
+
+			channelName := replicatedConfig.ChannelName
+			if channelName == "" {
+				channelName = license.Spec.ChannelName
+			}
+
 			params := apiserver.APIServerParams{
 				License:               license,
 				LicenseFields:         replicatedConfig.LicenseFields,
 				AppName:               replicatedConfig.AppName,
-				ChannelID:             replicatedConfig.ChannelID,
-				ChannelName:           replicatedConfig.ChannelName,
+				ChannelID:             channelID,
+				ChannelName:           channelName,
 				ChannelSequence:       replicatedConfig.ChannelSequence,
 				ReleaseSequence:       replicatedConfig.ReleaseSequence,
 				ReleaseCreatedAt:      replicatedConfig.ReleaseCreatedAt,


### PR DESCRIPTION
**TODO:** Unit tests for server param initialization (potentially as a larger refactor follow-up)

Fixes an issue where running an unauthenticated `helm install` of the SDK helm chart and passing `--set integration.licenseID=<license-id>` would result in 500 errors from replicated-app because no channel identifier was being passed.  This PR changes the logic so that the channel ID and name will be read from the license that is pulled on initialization.