### PR TITLE
silence api cmd usage

### DIFF
--- a/cmd/replicated/api.go
+++ b/cmd/replicated/api.go
@@ -16,9 +16,10 @@ import (
 
 func APICmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "api",
-		Short: "Starts the API server",
-		Long:  ``,
+		Use:          "api",
+		Short:        "Starts the API server",
+		Long:         ``,
+		SilenceUsage: true,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			viper.BindPFlags(cmd.Flags())
 		},

--- a/cmd/replicated/main.go
+++ b/cmd/replicated/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"os"
 )
 
 func main() {
 	if err := RootCmd().Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Silences usage for the `api` cli command since it currently makes reading errors more difficult. The message also gets logged twice currently, but cobra will handle that by default, so we don't need the extra print statement.

Before:
```
$ ./bin/replicated api --integration-license-id asdf --config-file /tmp/config.yaml
Error: only one of license in the config file or integration license id can be specified
Usage:
  replicated api [flags]

Flags:
      --config-file string              path to the replicated config file
  -h, --help                            help for api
      --integration-license-id string   the id of the license to use
      --namespace string                the namespace where the sdk/application is installed

Global Flags:
      --log-level string   set the log level (default "info")

only one of license in the config file or integration license id can be specified
```

After:
```
$ ./bin/replicated api --integration-license-id asdf --config-file /tmp/config.yaml
Error: only one of license in the config file or integration license id can be specified
```