### PR TITLE
remove gke autopilot distro check

### DIFF
--- a/pkg/heartbeat/app.go
+++ b/pkg/heartbeat/app.go
@@ -73,16 +73,20 @@ func GetHeartbeatInfo(sdkStore store.Store) *types.HeartbeatInfo {
 		ResourceStates:  sdkStore.GetAppStatus().ResourceStates,
 	}
 
-	// get kubernetes cluster version
-	k8sVersion, err := k8sutil.GetK8sVersion()
+	clientset, err := k8sutil.GetClientset()
 	if err != nil {
-		logger.Debugf("failed to get k8s version: %v", err.Error())
+		logger.Debugf("failed to get clientset: %v", err.Error())
 	} else {
-		r.K8sVersion = k8sVersion
-	}
+		k8sVersion, err := k8sutil.GetK8sVersion(clientset)
+		if err != nil {
+			logger.Debugf("failed to get k8s version: %v", err.Error())
+		} else {
+			r.K8sVersion = k8sVersion
+		}
 
-	if distribution := GetDistribution(); distribution != types.UnknownDistribution {
-		r.K8sDistribution = distribution.String()
+		if distribution := GetDistribution(clientset); distribution != types.UnknownDistribution {
+			r.K8sDistribution = distribution.String()
+		}
 	}
 
 	return &r

--- a/pkg/heartbeat/distribution.go
+++ b/pkg/heartbeat/distribution.go
@@ -11,25 +11,22 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func GetDistribution() types.Distribution {
+func GetDistribution(clientset kubernetes.Interface) types.Distribution {
 	// First try get the special ones. This is because sometimes we cannot get the distribution from the server version
-	clientset, err := k8sutil.GetClientset()
-	if err == nil {
-		if distribution := distributionFromServerGroupAndResources(clientset); distribution != types.UnknownDistribution {
-			return distribution
-		}
+	if distribution := distributionFromServerGroupAndResources(clientset); distribution != types.UnknownDistribution {
+		return distribution
+	}
 
-		if distribution := distributionFromProviderId(clientset); distribution != types.UnknownDistribution {
-			return distribution
-		}
+	if distribution := distributionFromProviderId(clientset); distribution != types.UnknownDistribution {
+		return distribution
+	}
 
-		if distribution := distributionFromLabels(clientset); distribution != types.UnknownDistribution {
-			return distribution
-		}
+	if distribution := distributionFromLabels(clientset); distribution != types.UnknownDistribution {
+		return distribution
 	}
 
 	// Getting distribution from server version string
-	k8sVersion, err := k8sutil.GetK8sVersion()
+	k8sVersion, err := k8sutil.GetK8sVersion(clientset)
 	if err != nil {
 		logger.Debugf("failed to get k8s version: %v", err.Error())
 		return types.UnknownDistribution

--- a/pkg/heartbeat/distribution.go
+++ b/pkg/heartbeat/distribution.go
@@ -12,7 +12,7 @@ import (
 )
 
 func GetDistribution() types.Distribution {
-	// First try get the special ones. This is because sometimes the server version string is for example GKE, while the actual server is GKE AutoPilot
+	// First try get the special ones. This is because sometimes we cannot get the distribution from the server version
 	clientset, err := k8sutil.GetClientset()
 	if err == nil {
 		if distribution := distributionFromServerGroupAndResources(clientset); distribution != types.UnknownDistribution {
@@ -45,8 +45,6 @@ func distributionFromServerGroupAndResources(clientset kubernetes.Interface) typ
 	_, resources, _ := clientset.Discovery().ServerGroupsAndResources()
 	for _, resource := range resources {
 		switch {
-		case strings.HasPrefix(resource.GroupVersion, "auto.gke.io/"):
-			return types.GKEAutoPilot
 		case strings.HasPrefix(resource.GroupVersion, "apps.openshift.io/"):
 			return types.OpenShift
 		case strings.HasPrefix(resource.GroupVersion, "run.tanzu.vmware.com/"):

--- a/pkg/heartbeat/distribution_test.go
+++ b/pkg/heartbeat/distribution_test.go
@@ -1,0 +1,228 @@
+package heartbeat
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/replicatedhq/replicated-sdk/pkg/heartbeat/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type mockClientsetForDistributionOpts struct {
+	objects       []runtime.Object
+	k8sVersion    string
+	groupVersions []string
+}
+
+func mockClientsetForDistribution(opts *mockClientsetForDistributionOpts) kubernetes.Interface {
+	clientset := fake.NewSimpleClientset(opts.objects...)
+	resources := []*metav1.APIResourceList{}
+	for _, groupVersion := range opts.groupVersions {
+		resources = append(resources, &metav1.APIResourceList{
+			GroupVersion: groupVersion,
+		})
+	}
+	clientset.Discovery().(*discoveryfake.FakeDiscovery).Resources = resources
+	clientset.Discovery().(*discoveryfake.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: opts.k8sVersion,
+	}
+	return clientset
+}
+
+func TestGetDistribution(t *testing.T) {
+	type args struct {
+		clientset kubernetes.Interface
+	}
+	tests := []struct {
+		name string
+		args args
+		want types.Distribution
+	}{
+		{
+			name: "openshift from api groups and resources",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					groupVersions: []string{"apps.openshift.io/v1"},
+					k8sVersion:    "v1.26.0",
+				}),
+			},
+			want: types.OpenShift,
+		},
+		{
+			name: "tanzu from api groups and resources",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					groupVersions: []string{"run.tanzu.vmware.com/v1"},
+					k8sVersion:    "v1.26.0",
+				}),
+			},
+			want: types.Tanzu,
+		},
+		{
+			name: "kind from provider id",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							Spec: corev1.NodeSpec{
+								ProviderID: "kind:foo",
+							},
+						},
+					},
+					k8sVersion: "v1.26.0",
+				}),
+			},
+			want: types.Kind,
+		},
+		{
+			name: "digitalocean from provider id",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							Spec: corev1.NodeSpec{
+								ProviderID: "digitalocean:foo",
+							},
+						},
+					},
+				}),
+			},
+			want: types.DigitalOcean,
+		},
+		{
+			name: "kurl from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"kurl.sh/cluster": "true",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: types.Kurl,
+		},
+		{
+			name: "microk8s from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"microk8s.io/cluster": "true",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: types.MicroK8s,
+		},
+		{
+			name: "azure from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"kubernetes.azure.com/role": "foo",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: types.AKS,
+		},
+		{
+			name: "minikube from labels",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					objects: []runtime.Object{
+						&corev1.Node{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"minikube.k8s.io/version": "123",
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: types.Minikube,
+		},
+		{
+			name: "gke from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0-gke.1",
+				}),
+			},
+			want: types.GKE,
+		},
+		{
+			name: "eks from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0-eks-1-123",
+				}),
+			},
+			want: types.EKS,
+		},
+		{
+			name: "rke2 from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0+rke2",
+				}),
+			},
+			want: types.RKE2,
+		},
+		{
+			name: "k3s from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0+k3s",
+				}),
+			},
+			want: types.K3s,
+		},
+		{
+			name: "k0s from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0+k0s",
+				}),
+			},
+			want: types.K0s,
+		},
+		{
+			name: "unknown from version",
+			args: args{
+				clientset: mockClientsetForDistribution(&mockClientsetForDistributionOpts{
+					k8sVersion: "v1.26.0",
+				}),
+			},
+			want: types.UnknownDistribution,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetDistribution(tt.args.clientset); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetDistribution() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/heartbeat/types/types.go
+++ b/pkg/heartbeat/types/types.go
@@ -12,7 +12,6 @@ const (
 	DigitalOcean
 	EKS
 	GKE
-	GKEAutoPilot
 	K0s
 	K3s
 	Kind
@@ -47,8 +46,6 @@ func (d Distribution) String() string {
 		return "eks"
 	case GKE:
 		return "gke"
-	case GKEAutoPilot:
-		return "gke-autopilot"
 	case K0s:
 		return "k0s"
 	case K3s:

--- a/pkg/k8sutil/clientset.go
+++ b/pkg/k8sutil/clientset.go
@@ -62,11 +62,7 @@ func GetClusterConfig() (*rest.Config, error) {
 	return cfg, nil
 }
 
-func GetK8sVersion() (string, error) {
-	clientset, err := GetClientset()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create kubernetes clientset")
-	}
+func GetK8sVersion(clientset kubernetes.Interface) (string, error) {
 	k8sVersion, err := clientset.Discovery().ServerVersion()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get kubernetes server version")


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/82294/sdk-install-shows-gke-autopilot-for-non-autopilot-cluster

This check doesn't work as intended.  It checks for the presence of an `auto.gke.io` resource group, but both standard and autopilot clusters can have this.  The proposal for now is to just remove the standard vs autopilot distinction and call them both GKE.