### PR TITLE
use wolfi-base to install go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM cgr.dev/chainguard/go:1.20 as builder
+FROM cgr.dev/chainguard/wolfi-base:latest as local_go
+
+RUN apk update && apk add ca-certificates-bundle build-base openssh go-1.20~=1.20.7
+ENTRYPOINT /usr/bin/go
+
+FROM local_go as builder
 
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/replicated-sdk
 WORKDIR $PROJECTPATH


### PR DESCRIPTION
Fixes https://github.com/replicatedhq/replicated-sdk/issues/66

Migration guide: https://www.chainguard.dev/unchained/a-guide-on-how-to-use-chainguard-images-for-public-catalog-tier-users