### PR TITLE
Fix supportbundle secret syntax

### DIFF
--- a/chart/templates/replicated-sdk-supportbundle.yaml
+++ b/chart/templates/replicated-sdk-supportbundle.yaml
@@ -20,5 +20,7 @@ stringData:
         - logs:
             collectorName: replicated-sdk-logs
             selector:
-              {{- include "replicated-sdk.labels" . | nindent 14 }}
+              {{- range $k, $v := (include "replicated-sdk.labels" . | fromYaml) }}
+              - {{ $k }}={{ $v }}
+              {{- end }} 
             name: replicated-sdk/logs


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Fixes the support bundle secret syntax so that generating a support bundle works.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where generating a support bundle using the Replicated SDK's support bundle secret that's part of the Helm chart failed due to a syntax issue where the `selector` field expected an array of strings instead of a map.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE