### PR TITLE
request updates in descending order

### DIFF
--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -44,6 +44,7 @@ func GetUpdates(sdkStore store.Store, license *kotsv1beta1.License, currentCurso
 	urlValues.Set("channelSequence", channelSequenceStr)
 	urlValues.Add("licenseSequence", fmt.Sprintf("%d", license.Spec.LicenseSequence))
 	urlValues.Add("isSemverSupported", "true")
+	urlValues.Add("sortOrder", "desc")
 
 	url := fmt.Sprintf("%s://%s/release/%s/pending?%s", u.Scheme, hostname, license.Spec.AppSlug, urlValues.Encode())
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This PR adds the `sortOrder` query parameter to the pending updates request with a value of `desc` so that pending channel releases are returned in order from newest to oldest.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [SC-84514](https://app.shortcut.com/replicated/story/84514/sdk-should-display-pending-updates-in-order-from-newest-to-oldest)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

Install the SDK, promote some channel releases, and test the `/api/v1/app/updates` endpoint

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Pending updates returned by the `/api/v1/app/updates` endpoint will now show in order from newest to oldest.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE