### PR TITLE
Add support for OpenShift clusters

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -11,16 +11,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "replicated-sdk.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s" $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+  {{- if .Values.fullnameOverride }}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- $name := default .Chart.Name .Values.nameOverride }}
+    {{- if contains $name .Release.Name }}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+      {{- printf "%s" $name | trunc 63 | trimSuffix "-" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{/*
@@ -54,20 +54,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 License Fields
 */}}
 {{- define "replicated-sdk.licenseFields" -}}
-{{- if (((.Values.global).replicated).licenseFields) -}}
-{{- .Values.global.replicated.licenseFields | toYaml -}}
-{{- else if .Values.licenseFields -}}
-{{- .Values.licenseFields | toYaml -}}
-{{- end -}}
+  {{- if (((.Values.global).replicated).licenseFields) -}}
+    {{- .Values.global.replicated.licenseFields | toYaml -}}
+  {{- else if .Values.licenseFields -}}
+    {{- .Values.licenseFields | toYaml -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
-Create the name of the service account to use
+Is OpenShift
 */}}
-{{- define "replicated-sdk.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "replicated-sdk.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{- define "replicated-sdk.isOpenShift" -}}
+  {{- $isOpenShift := false }}
+  {{- range .Capabilities.APIVersions -}}
+    {{- if hasPrefix "apps.openshift.io/" . -}}
+      {{- $isOpenShift = true }}
+    {{- end -}}
+  {{- end -}}
+  {{- $isOpenShift }}
 {{- end }}

--- a/chart/templates/replicated-sdk-deployment.yaml
+++ b/chart/templates/replicated-sdk-deployment.yaml
@@ -1,3 +1,12 @@
+{{- $podSecurityContext := .Values.podSecurityContext }}
+{{ if eq (include "replicated-sdk.isOpenShift" .) "true" }}
+  {{ if eq ($podSecurityContext.runAsUser | int) 1001 }}
+    {{- $_ := unset $podSecurityContext "runAsUser" }}
+  {{- end }}
+  {{ if eq ($podSecurityContext.runAsGroup | int) 1001 }}
+    {{- $_ := unset $podSecurityContext "runAsGroup" }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -17,6 +26,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if $podSecurityContext.enabled }}
+      securityContext: {{- omit $podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       volumes:
       - name: replicated-sdk
         secret:
@@ -25,6 +37,9 @@ spec:
       - name: replicated-sdk
         image: {{ index .Values.images "replicated-sdk" }}
         imagePullPolicy: IfNotPresent
+        {{- if .Values.containerSecurityContext.enabled }}
+        securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: replicated-sdk
           mountPath: /etc/replicated-sdk/config.yaml
@@ -75,8 +90,4 @@ spec:
             cpu: 100m
             memory: 100Mi
       restartPolicy: Always
-      securityContext:
-        fsGroup: 1001
-        runAsUser: 1001
       serviceAccountName: {{ .Values.serviceAccountName | default "replicated-sdk" }}
-status: {}

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -24,14 +24,20 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
+containerSecurityContext:
+  enabled: true
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+podSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  seccompProfile:
+    type: "RuntimeDefault"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Adds support for OpenShift clusters. OpenShift requires the user/group IDs to fall within the dynamically generated range that's assigned to the namespace after creation. Since it's difficult to know that at installation time, OpenShift automatically assigns a user ID if it's not specified.

This PR adds functionality to detect if the cluster is OpenShift, and omits the `runAsUser` and `runAsGroup` fields from the `podSecurityContext` so that OpenShift can dynamically/automatically assign the user ID.

Also, OpenShift applies the `restricted-v2` security context constraints by default, which requires containers to:

- Run as non-root.
- Have a read-only root filesystem.
- Disable privilege escalation.
- Drop all OS capabilities.
- Use `RuntimeDefault` as the `seccompProfile`.

And this PR addresses that.

This pattern was inspired by the Bitnami charts. Examples:

- https://github.com/bitnami/charts/blob/65635cedba99c5c77d4367198af46dd8582e5485/bitnami/postgresql/values.yaml#L456-L458
- https://github.com/bitnami/charts/blob/65635cedba99c5c77d4367198af46dd8582e5485/bitnami/postgresql/values.yaml#L469-L479
- https://github.com/bitnami/charts/blob/9dbc7bc149568e9210203c1b314851266f1ef88d/bitnami/tomcat/templates/_pod.tpl#L63-L65
- https://github.com/bitnami/charts/blob/9dbc7bc149568e9210203c1b314851266f1ef88d/bitnami/tomcat/templates/_pod.tpl#L151-L153

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for OpenShift clusters.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE