### PR TITLE
API to accept metrics from application

### DIFF
--- a/pact/custom_metrics_test.go
+++ b/pact/custom_metrics_test.go
@@ -1,0 +1,88 @@
+package pact
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/replicated-sdk/pkg/handlers"
+	"github.com/replicatedhq/replicated-sdk/pkg/store"
+)
+
+func TestSendCustomApplicationMetrics(t *testing.T) {
+	// Happy path only
+
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"key1_string":         "val1",
+			"key2_int":            5,
+			"key3_float":          1.5,
+			"key4_numeric_string": "1.6",
+		},
+	}
+	customMetricsData, _ := json.Marshal(data)
+	license := &v1beta1.License{
+		Spec: v1beta1.LicenseSpec{
+			LicenseID: "sdk-license-customer-0-license",
+			AppSlug:   "sdk-license-app",
+			Endpoint:  fmt.Sprintf("http://%s:%d", pact.Host, pact.Server.Port),
+		},
+	}
+
+	clientWriter := httptest.NewRecorder()
+	clientRequest := &http.Request{
+		Body: io.NopCloser(bytes.NewBuffer(customMetricsData)),
+		Header: http.Header{
+			"Authorization": []string{license.Spec.LicenseID},
+		},
+	}
+
+	pactInteraction := func() {
+		pact.
+			AddInteraction().
+			Given("Send valid custom metrics").
+			UponReceiving("A request to send custom metrics").
+			WithRequest(dsl.Request{
+				Method: http.MethodPost,
+				Headers: dsl.MapMatcher{
+					"User-Agent":    dsl.String("Replicated-SDK/v0.0.0-unknown"),
+					"Authorization": dsl.String(fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID))))),
+				},
+				Path: dsl.String("/application/custom-metrics"),
+				Body: data,
+			}).
+			WillRespondWith(dsl.Response{
+				Status: http.StatusOK,
+			})
+	}
+	t.Run("Send valid custom metrics", func(t *testing.T) {
+		pactInteraction()
+
+		storeOptions := store.InitInMemoryStoreOptions{
+			License:               license,
+			LicenseFields:         nil,
+			ReplicatedAppEndpoint: license.Spec.Endpoint,
+		}
+		if err := store.InitInMemory(storeOptions); err != nil {
+			t.Fatalf("Error on InitInMemory: %v", err)
+		}
+		defer store.SetStore(nil)
+
+		if err := pact.Verify(func() error {
+			handlers.SendCustomApplicationMetrics(clientWriter, clientRequest)
+			if clientWriter.Code != http.StatusOK {
+				return fmt.Errorf("expected status code %d but got %d", http.StatusOK, clientWriter.Code)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("Error on Verify: %v", err)
+		}
+	})
+}

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -66,6 +66,9 @@ func Start(params APIServerParams) {
 	r.HandleFunc("/api/v1/integration/mock-data", handlers.EnforceMockAccess(handlers.GetIntegrationMockData)).Methods("GET")
 	r.HandleFunc("/api/v1/integration/status", handlers.EnforceMockAccess(handlers.GetIntegrationStatus)).Methods("GET")
 
+	// Custom metrics
+	r.HandleFunc("/api/v1/app/custom-metrics", handlers.SendCustomApplicationMetrics).Methods("POST")
+
 	srv := &http.Server{
 		Handler: r,
 		Addr:    ":3000",

--- a/pkg/handlers/custom_metrics.go
+++ b/pkg/handlers/custom_metrics.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated-sdk/pkg/logger"
+	"github.com/replicatedhq/replicated-sdk/pkg/metrics"
+	"github.com/replicatedhq/replicated-sdk/pkg/store"
+	"github.com/replicatedhq/replicated-sdk/pkg/util"
+)
+
+type SendCustomApplicationMetricsRequest struct {
+	Data ApplicationMetricsData `json:"data"`
+}
+
+type ApplicationMetricsData map[string]interface{}
+
+func SendCustomApplicationMetrics(w http.ResponseWriter, r *http.Request) {
+	license := store.GetStore().GetLicense()
+	if r.Header.Get("Authorization") != license.Spec.LicenseID {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	if util.IsAirgap() {
+		JSON(w, http.StatusForbidden, "This request cannot be satisfied in airgap mode")
+		return
+	}
+
+	request := SendCustomApplicationMetricsRequest{}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		logger.Error(errors.Wrap(err, "decode request"))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if err := validateCustomMetricsData(request.Data); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		return
+	}
+
+	err := metrics.SendApplicationMetricsData(store.GetStore(), license, request.Data)
+	if err != nil {
+		logger.Error(errors.Wrap(err, "set application data"))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	JSON(w, http.StatusOK, "")
+}
+
+func validateCustomMetricsData(data ApplicationMetricsData) error {
+	if len(data) == 0 {
+		return errors.New("no data provided")
+	}
+
+	for key, val := range data {
+		valType := reflect.TypeOf(val)
+		switch valType.Kind() {
+		case reflect.Slice:
+			return errors.Errorf("%s value is an array, only scalar values are allowed", key)
+		case reflect.Array:
+			return errors.Errorf("%s value is an array, only scalar values are allowed", key)
+		case reflect.Map:
+			return errors.Errorf("%s value is a map, only scalar values are allowed", key)
+		}
+	}
+
+	return nil
+}

--- a/pkg/handlers/custom_metrics_test.go
+++ b/pkg/handlers/custom_metrics_test.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateCustomMetricsData(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    ApplicationMetricsData
+		wantErr bool
+	}{
+		{
+			name: "all values are valid",
+			data: ApplicationMetricsData{
+				"key1": "val1",
+				"key2": 6,
+				"key3": 6.6,
+				"key4": true,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "no data",
+			data:    ApplicationMetricsData{},
+			wantErr: true,
+		},
+		{
+			name: "array value",
+			data: ApplicationMetricsData{
+				"key1": 10,
+				"key2": []string{"val1", "val2"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "map value",
+			data: ApplicationMetricsData{
+				"key1": 10,
+				"key2": map[string]string{"key1": "val1"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateCustomMetricsData(test.data)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,77 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+	kotsv1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/replicatedhq/replicated-sdk/pkg/heartbeat"
+	"github.com/replicatedhq/replicated-sdk/pkg/store"
+	"github.com/replicatedhq/replicated-sdk/pkg/util"
+)
+
+func SendApplicationMetricsData(sdkStore store.Store, license *kotsv1beta1.License, data map[string]interface{}) error {
+	endpoint := sdkStore.GetReplicatedAppEndpoint()
+	if endpoint == "" {
+		endpoint = license.Spec.Endpoint
+	}
+
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse endpoint")
+	}
+
+	hostname := u.Hostname()
+	if u.Port() != "" {
+		hostname = fmt.Sprintf("%s:%s", u.Hostname(), u.Port())
+	}
+
+	url := fmt.Sprintf("%s://%s/application/custom-metrics", u.Scheme, hostname)
+
+	payload := struct {
+		Data map[string]interface{} `json:"data"`
+	}{
+		Data: data,
+	}
+
+	reqBody, err := json.Marshal(payload)
+	if err != nil {
+		return errors.Wrap(err, "marshal data")
+	}
+
+	req, err := util.NewRequest("POST", url, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return errors.Wrap(err, "call newrequest")
+	}
+
+	req.SetBasicAuth(license.Spec.LicenseID, license.Spec.LicenseID)
+	req.Header.Set("Content-Type", "application/json")
+
+	heartbeatInfo := heartbeat.GetHeartbeatInfo(sdkStore)
+	heartbeat.InjectHeartbeatInfoHeaders(req, heartbeatInfo)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute get request")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read response body")
+	}
+
+	if resp.StatusCode >= 400 {
+		if len(body) > 0 {
+			return util.ActionableError{Message: string(body)}
+		}
+		return errors.Errorf("unexpected result from get request: %d", resp.StatusCode)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

https://app.shortcut.com/replicated/story/85778/endpoint-in-kots-to-receive-dispatch-custom-metrics-to-replicated-app

This add an API endpoint for application to report custom metrics.  The metrics payload is a flat json object where each key is a scalar value.  Data is forwarded to replicated.app synchronously.

replicated.app endpoint does not yet exist and will be updated before this PR is merged.


#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds replicated-sdk API to send custom application metrics to replicated.app service
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
Yes, TODO.