### PR TITLE
fix running CI in main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Fixes: https://github.com/replicatedhq/replicated-sdk/actions/runs/5967728367/workflow

`head_ref` is only defined on pull requests. This PR adds changes to fallback to the `run_id` when `head_ref` is not defined (e.g. when running the workflow on the `main` branch). It also prefixes the concurrency group with `${{ github.workflow }}-` so that only (previous) jobs from that particular workflow get cancelled.

References:

- https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
- https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE