### PR TITLE
Make the chart/api work with helm template + kubectl

### DIFF
--- a/.github/actions/validate-endpoints/action.yml
+++ b/.github/actions/validate-endpoints/action.yml
@@ -122,10 +122,9 @@ runs:
             echo "Expected app history to be 0 when deployed via kubectl and integration is disabled, but is '$historyLength'."
             exit 1
           fi
-          exit 0
-        fi
-
-        if [ $historyLength -lt 1 ]; then
-          echo "No app history found."
-          exit 1
+        else
+          if [ $historyLength -lt 1 ]; then
+            echo "No app history found."
+            exit 1
+          fi
         fi

--- a/.github/actions/validate-endpoints/action.yml
+++ b/.github/actions/validate-endpoints/action.yml
@@ -122,6 +122,7 @@ runs:
             echo "Expected app history to be 0 when deployed via kubectl and integration is disabled, but is '$historyLength'."
             exit 1
           fi
+          exit 0
         fi
 
         if [ $historyLength -lt 1 ]; then

--- a/.github/actions/validate-endpoints/action.yml
+++ b/.github/actions/validate-endpoints/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'If integration mode is enabled or not'
     required: false
     default: 'false'
+  deployed-via-kubectl:
+    description: 'If the chart was deployed via kubectl after running helm template'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -112,6 +116,13 @@ runs:
       shell: bash
       run: |
         historyLength=$(curl -s --fail --show-error localhost:8888/api/v1/app/history | jq '.releases | length' | tr -d '\n')
+
+        if [ "${{ inputs.deployed-via-kubectl }}" == "true" ] && [ "${{ inputs.integration-enabled }}" == "false" ]; then
+          if [ $historyLength -ne 0 ]; then
+            echo "Expected app history to be 0 when deployed via kubectl and integration is disabled, but is '$historyLength'."
+            exit 1
+          fi
+        fi
 
         if [ $historyLength -lt 1 ]; then
           echo "No app history found."

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,10 +64,52 @@ jobs:
             exit 1
           fi
 
+          if echo $output | grep -q 'kind: ConfigMap'; then
+            printf "legacy/deprecated configmap should not exist:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          if ! echo $output | grep -q 'kind: ServiceAccount'; then
+            printf "default service account should exist if user does not set serviceAccountName:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          if ! echo $output | grep -q 'kind: Role'; then
+            printf "default role should exist if user does not set serviceAccountName:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          if ! echo $output | grep -q 'kind: RoleBinding'; then
+            printf "default rolebinding should exist if user does not set serviceAccountName:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
           output=$(helm template oci://ttl.sh/automated-${{ github.run_id }}/replicated-sdk --version 0.0.0 --set integration.enabled=true)
 
           if ! echo $output | grep -q integration-enabled; then
             printf "'integration-enabled' key should exist if value is set by the user:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          output=$(helm template oci://ttl.sh/automated-${{ github.run_id }}/replicated-sdk --version 0.0.0 --set serviceAccountName=foo)
+
+          if echo $output | grep -q 'kind: ServiceAccount'; then
+            printf "default service account should not exist if user sets serviceAccountName:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          if echo $output | grep -q 'kind: Role'; then
+            printf "default role should not exist if user sets serviceAccountName:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          if echo $output | grep -q 'kind: RoleBinding'; then
+            printf "default rolebinding should not exist if user sets serviceAccountName:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          if ! echo $output | grep -q 'serviceAccountName: foo'; then
+            printf "user-set serviceAccountName reference should exist:\n\n%s\n\n" "$output"
             exit 1
           fi
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -241,7 +241,7 @@ jobs:
         run: |
           helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart | kubectl apply -f -
           kubectl rollout status deployment test-chart --timeout=2m
-          kubeclt rollout status deployment replicated-sdk --timeout=2m
+          kubectl rollout status deployment replicated-sdk --timeout=2m
 
       - name: Validate endpoints
         uses: ./.github/actions/validate-endpoints
@@ -276,7 +276,7 @@ jobs:
         run: |
           helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated-sdk.integration.enabled=false | kubectl apply -f -
           kubectl rollout status deployment test-chart --timeout=2m
-          kubeclt rollout status deployment replicated-sdk --timeout=2m
+          kubectl rollout status deployment replicated-sdk --timeout=2m
 
       - name: Validate endpoints
         uses: ./.github/actions/validate-endpoints

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,7 +190,7 @@ jobs:
           ttl: 2h
           export-kubeconfig: true
 
-      - name: Install as standalone in integration mode
+      - name: Install via Helm as standalone in integration mode
         run: helm install replicated-sdk oci://ttl.sh/automated-${{ github.run_id }}/replicated-sdk --version 0.0.0 --set integration.licenseID=$LICENSE_ID --wait --timeout 2m
 
       - name: Validate endpoints
@@ -200,13 +200,31 @@ jobs:
           license-fields: ${{ env.LICENSE_FIELDS }}
           integration-enabled: 'true'
 
-      - name: Uninstall replicated-sdk
+      - name: Uninstall replicated-sdk via Helm
         run: helm uninstall replicated-sdk --wait --timeout 2m
+
+      - name: Install via kubectl as standalone in integration mode
+        run: |
+          helm template replicated-sdk oci://ttl.sh/automated-${{ github.run_id }}/replicated-sdk --version 0.0.0 --set integration.licenseID=$LICENSE_ID | kubectl apply -f -
+          kubectl rollout status deployment replicated-sdk --timeout=2m
+
+      - name: Validate endpoints
+        uses: ./.github/actions/validate-endpoints
+        with:
+          license-id: ${{ env.LICENSE_ID }}
+          license-fields: ${{ env.LICENSE_FIELDS }}
+          integration-enabled: 'true'
+          deployed-via-kubectl: 'true'
+
+      - name: Uninstall replicated-sdk via kubectl
+        run: |
+          helm template replicated-sdk oci://ttl.sh/automated-${{ github.run_id }}/replicated-sdk --version 0.0.0 --set integration.licenseID=$LICENSE_ID | kubectl delete -f -
+          kubectl wait --for=delete deployment/replicated-sdk --timeout=2m
 
       - name: Login to registry
         run: helm registry login registry.replicated.com --username $LICENSE_ID --password $LICENSE_ID
 
-      - name: Install as subchart in integration mode
+      - name: Install via Helm as subchart in integration mode
         run: helm install test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --wait --timeout 2m
 
       - name: Validate endpoints
@@ -216,11 +234,31 @@ jobs:
           license-fields: ${{ env.LICENSE_FIELDS }}
           integration-enabled: 'true'
 
-      - name: Uninstall test-chart
+      - name: Uninstall test-chart via Helm
         run: helm uninstall test-chart --wait --timeout 2m
 
+      - name: Install via kubectl as subchart in integration mode
+        run: |
+          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart | kubectl apply -f -
+          kubectl rollout status deployment test-chart --timeout=2m
+          kubeclt rollout status deployment replicated-sdk --timeout=2m
+
+      - name: Validate endpoints
+        uses: ./.github/actions/validate-endpoints
+        with:
+          license-id: ${{ env.LICENSE_ID }}
+          license-fields: ${{ env.LICENSE_FIELDS }}
+          integration-enabled: 'true'
+          deployed-via-kubectl: 'true'
+
+      - name: Uninstall test-chart via kubectl
+        run: |
+          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart | kubectl delete -f -
+          kubectl wait --for=delete deployment/test-chart --timeout=2m
+          kubectl wait --for=delete deployment/replicated-sdk --timeout=2m
+
       # we have to explicitly disable integration mode here because we're using a "dev" license
-      - name: Install as subchart in production mode
+      - name: Install via Helm as subchart in production mode
         run: helm install test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated-sdk.integration.enabled=false --wait --timeout 2m
 
       - name: Validate endpoints
@@ -229,6 +267,30 @@ jobs:
           license-id: ${{ env.LICENSE_ID }}
           license-fields: ${{ env.LICENSE_FIELDS }}
           integration-enabled: 'false'
+
+      - name: Uninstall test-chart via Helm
+        run: helm uninstall test-chart --wait --timeout 2m
+
+      # we have to explicitly disable integration mode here because we're using a "dev" license
+      - name: Install via kubectl as subchart in production mode
+        run: |
+          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated-sdk.integration.enabled=false | kubectl apply -f -
+          kubectl rollout status deployment test-chart --timeout=2m
+          kubeclt rollout status deployment replicated-sdk --timeout=2m
+
+      - name: Validate endpoints
+        uses: ./.github/actions/validate-endpoints
+        with:
+          license-id: ${{ env.LICENSE_ID }}
+          license-fields: ${{ env.LICENSE_FIELDS }}
+          integration-enabled: 'false'
+          deployed-via-kubectl: 'true'
+
+      - name: Uninstall test-chart via kubectl
+        run: |
+          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated-sdk.integration.enabled=false | kubectl delete -f -
+          kubectl wait --for=delete deployment/test-chart --timeout=2m
+          kubectl wait --for=delete deployment/replicated-sdk --timeout=2m
 
       - name: Remove Cluster
         uses: replicatedhq/replicated-actions/remove-cluster@v1.1.1

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -31,6 +31,17 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments.
+*/}}
+{{- define "replicated-sdk.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "replicated-sdk.labels" -}}

--- a/chart/templates/replicated-sdk-configmap.yaml
+++ b/chart/templates/replicated-sdk-configmap.yaml
@@ -1,3 +1,9 @@
+{{/*
+This is a legacy/deprecated configmap.
+The replicated API will use the deployment uid as the app-id and replicated-sdk-id if the configmap does not exist.
+*/}}
+{{- $data := (lookup "v1" "ConfigMap" .Release.Namespace "replicated-sdk").data }}
+{{- if $data }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,11 +11,6 @@ metadata:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
   name: replicated-sdk
 data:
-{{- $data := (lookup "v1" "ConfigMap" .Release.Namespace "replicated-sdk").data }}
-{{- if $data }}
   replicated-sdk-id: {{ index $data "replicated-sdk-id" }}
   app-id: {{ index $data "app-id" }}
-{{- else }}
-  replicated-sdk-id: {{ uuidv4 }}
-  app-id: {{ uuidv4 }}
 {{- end }}

--- a/chart/templates/replicated-sdk-configmap.yaml
+++ b/chart/templates/replicated-sdk-configmap.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
   name: replicated-sdk
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 data:
   replicated-sdk-id: {{ index $data "replicated-sdk-id" }}
   app-id: {{ index $data "app-id" }}

--- a/chart/templates/replicated-sdk-deployment.yaml
+++ b/chart/templates/replicated-sdk-deployment.yaml
@@ -50,6 +50,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: REPLICATED_SDK_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: IS_HELM_MANAGED
           value: "true"
         - name: HELM_RELEASE_NAME

--- a/chart/templates/replicated-sdk-deployment.yaml
+++ b/chart/templates/replicated-sdk-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
   name: replicated-sdk
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 spec:
   selector:
     matchLabels:
@@ -60,8 +61,6 @@ spec:
           value: {{ .Release.Name }}
         - name: HELM_RELEASE_NAMESPACE
           value: {{ .Release.Namespace }}
-        - name: HELM_RELEASE_REVISION
-          value: {{ .Release.Revision | quote }}
         - name: HELM_PARENT_CHART_URL
           value: {{ .Values.parentChartURL | default "" | quote }}
         - name: HELM_DRIVER

--- a/chart/templates/replicated-sdk-role.yaml
+++ b/chart/templates/replicated-sdk-role.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
   name: replicated-sdk-role
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 rules:
 - apiGroups:
   - '*'

--- a/chart/templates/replicated-sdk-rolebinding.yaml
+++ b/chart/templates/replicated-sdk-rolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
   name: replicated-sdk-rolebinding
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -12,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: replicated-sdk
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 {{ end }}

--- a/chart/templates/replicated-sdk-secret.yaml
+++ b/chart/templates/replicated-sdk-secret.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
   name: replicated-sdk
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 type: Opaque
 stringData:
   config.yaml: |

--- a/chart/templates/replicated-sdk-service.yaml
+++ b/chart/templates/replicated-sdk-service.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
   name: replicated-sdk
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 spec:
   ports:
   - name: http

--- a/chart/templates/replicated-sdk-serviceaccount.yaml
+++ b/chart/templates/replicated-sdk-serviceaccount.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
   name: replicated-sdk
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 {{ end }}

--- a/chart/templates/replicated-sdk-supportbundle.yaml
+++ b/chart/templates/replicated-sdk-supportbundle.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "replicated-sdk.labels" . | nindent 4 }}
     troubleshoot.io/kind: support-bundle
   name: replicated-sdk-supportbundle
+  namespace: {{ include "replicated-sdk.namespace" . | quote }}
 stringData:
   support-bundle-spec: |-
     apiVersion: troubleshoot.sh/v1beta2

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -23,6 +23,7 @@ serviceAccountName: ""
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+namespaceOverride: ""
 
 containerSecurityContext:
   enabled: true

--- a/pact/heartbeat_test.go
+++ b/pact/heartbeat_test.go
@@ -22,9 +22,9 @@ func TestSendAppHeartbeat(t *testing.T) {
 
 	mockStore := mock_store.NewMockStore(ctrl)
 	clientset := fake.NewSimpleClientset(
-		k8sutil.CreateTestDeployment("replicated-sdk", "test-namespace", "1", map[string]string{"app": "test-app"}),
-		k8sutil.CreateTestReplicaSet("test-replicaset", "test-namespace", "1"),
-		k8sutil.CreateTestPod("test-pod", "test-namespace", "test-replicaset", map[string]string{"app": "test-app"}),
+		k8sutil.CreateTestDeployment("replicated-sdk", "sdk-heartbeat-namespace", "1", map[string]string{"app": "sdk-heartbeat-app"}),
+		k8sutil.CreateTestReplicaSet("sdk-heartbeat-replicaset", "sdk-heartbeat-namespace", "1"),
+		k8sutil.CreateTestPod("sdk-heartbeat-pod", "sdk-heartbeat-namespace", "sdk-heartbeat-replicaset", map[string]string{"app": "sdk-heartbeat-app"}),
 	)
 
 	tests := []struct {

--- a/pact/heartbeat_test.go
+++ b/pact/heartbeat_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -28,8 +27,7 @@ func TestSendAppHeartbeat(t *testing.T) {
 		k8sutil.CreateTestPod("sdk-heartbeat-pod", "sdk-heartbeat-namespace", "sdk-heartbeat-replicaset", map[string]string{"app": "sdk-heartbeat-app"}),
 	)
 
-	os.Setenv("REPLICATED_SDK_POD_NAME", "sdk-heartbeat-pod")
-	defer os.Unsetenv("REPLICATED_SDK_POD_NAME")
+	t.Setenv("REPLICATED_SDK_POD_NAME", "sdk-heartbeat-pod")
 
 	tests := []struct {
 		name                  string

--- a/pact/heartbeat_test.go
+++ b/pact/heartbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -26,6 +27,9 @@ func TestSendAppHeartbeat(t *testing.T) {
 		k8sutil.CreateTestReplicaSet("sdk-heartbeat-replicaset", "sdk-heartbeat-namespace", "1"),
 		k8sutil.CreateTestPod("sdk-heartbeat-pod", "sdk-heartbeat-namespace", "sdk-heartbeat-replicaset", map[string]string{"app": "sdk-heartbeat-app"}),
 	)
+
+	os.Setenv("REPLICATED_SDK_POD_NAME", "sdk-heartbeat-pod")
+	defer os.Unsetenv("REPLICATED_SDK_POD_NAME")
 
 	tests := []struct {
 		name                  string

--- a/pact/heartbeat_test.go
+++ b/pact/heartbeat_test.go
@@ -34,6 +34,7 @@ func TestSendAppHeartbeat(t *testing.T) {
 						Endpoint:  fmt.Sprintf("http://%s:%d", pact.Host, pact.Server.Port),
 					},
 				})
+				mockStore.EXPECT().GetNamespace().Return("sdk-heartbeat-namespace")
 				mockStore.EXPECT().GetReplicatedSDKID().Return("sdk-heartbeat-cluster-id")
 				mockStore.EXPECT().GetAppID().Return("sdk-heartbeat-app")
 				mockStore.EXPECT().GetChannelID().Return("sdk-heartbeat-app-nightly")
@@ -84,6 +85,7 @@ func TestSendAppHeartbeat(t *testing.T) {
 						Endpoint:  fmt.Sprintf("http://%s:%d", pact.Host, pact.Server.Port),
 					},
 				})
+				mockStore.EXPECT().GetNamespace().Return("sdk-heartbeat-namespace")
 				mockStore.EXPECT().GetReplicatedSDKID().Return("sdk-heartbeat-cluster-id")
 				mockStore.EXPECT().GetAppID().Return("sdk-heartbeat-app")
 				mockStore.EXPECT().GetChannelID().Return("sdk-heartbeat-app-beta")
@@ -134,6 +136,7 @@ func TestSendAppHeartbeat(t *testing.T) {
 						Endpoint:  fmt.Sprintf("http://%s:%d", pact.Host, pact.Server.Port),
 					},
 				})
+				mockStore.EXPECT().GetNamespace().Return("sdk-heartbeat-namespace")
 				mockStore.EXPECT().GetReplicatedSDKID().Return("sdk-heartbeat-cluster-id")
 				mockStore.EXPECT().GetAppID().Return("sdk-heartbeat-app")
 				mockStore.EXPECT().GetChannelID().Return("sdk-heartbeat-app-beta")
@@ -184,6 +187,7 @@ func TestSendAppHeartbeat(t *testing.T) {
 						Endpoint:  fmt.Sprintf("http://%s:%d", pact.Host, pact.Server.Port),
 					},
 				})
+				mockStore.EXPECT().GetNamespace().Return("sdk-heartbeat-namespace")
 				mockStore.EXPECT().GetReplicatedSDKID().Return("sdk-heartbeat-cluster-id")
 				mockStore.EXPECT().GetAppID().Return("sdk-heartbeat-app")
 				mockStore.EXPECT().GetChannelID().Return("sdk-heartbeat-app-nightly")

--- a/pact/license_test.go
+++ b/pact/license_test.go
@@ -215,10 +215,10 @@ spec:
 			if err := pact.Verify(func() error {
 				got, err := license.GetLatestLicense(tt.args.license, tt.args.endpoint)
 				if (err != nil) != tt.wantErr {
-					t.Errorf("SendAppHeartbeat() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("GetLatestLicense() error = %v, wantErr %v", err, tt.wantErr)
 				}
 				if !reflect.DeepEqual(got, tt.want) {
-					t.Errorf("SendAppHeartbeat() got = %v, want %v", got, tt.want)
+					t.Errorf("GetLatestLicense() got = %v, want %v", got, tt.want)
 				}
 				return nil
 			}); err != nil {

--- a/pkg/apiserver/bootstrap.go
+++ b/pkg/apiserver/bootstrap.go
@@ -122,11 +122,13 @@ func bootstrap(params APIServerParams) error {
 			return errors.Wrap(err, "failed to get helm release")
 		}
 
-		i, err := appstate.GenerateStatusInformersForManifest(helmRelease.Manifest)
-		if err != nil {
-			return errors.Wrap(err, "failed to generate status informers")
+		if helmRelease != nil {
+			i, err := appstate.GenerateStatusInformersForManifest(helmRelease.Manifest)
+			if err != nil {
+				return errors.Wrap(err, "failed to generate status informers")
+			}
+			informers = i
 		}
-		informers = i
 	}
 
 	appStateOperator.ApplyAppInformers(appstatetypes.AppInformersArgs{

--- a/pkg/appstate/operator.go
+++ b/pkg/appstate/operator.go
@@ -103,6 +103,20 @@ func (o *Operator) ApplyAppInformers(args types.AppInformersArgs) {
 		informers = append(informers, informer)
 	}
 
+	if len(informers) == 0 {
+		// no informers, set state to ready and return
+		defaultReadyStatus := types.AppStatus{
+			AppSlug:   appSlug,
+			UpdatedAt: time.Now(),
+			State:     types.StateReady,
+			Sequence:  sequence,
+		}
+		if err := o.setAppStatus(defaultReadyStatus); err != nil {
+			log.Printf("error updating app status: %v", err)
+		}
+		return
+	}
+
 	o.appStateMonitor.Apply(appSlug, sequence, informers)
 }
 

--- a/pkg/appstate/operator.go
+++ b/pkg/appstate/operator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/replicated-sdk/pkg/appstate/types"
 	"github.com/replicatedhq/replicated-sdk/pkg/heartbeat"
+	"github.com/replicatedhq/replicated-sdk/pkg/k8sutil"
 	"github.com/replicatedhq/replicated-sdk/pkg/logger"
 	"github.com/replicatedhq/replicated-sdk/pkg/store"
 	"github.com/replicatedhq/replicated-sdk/pkg/util"
@@ -127,8 +128,12 @@ func (o *Operator) setAppStatus(newAppStatus types.AppStatus) error {
 	if newAppStatus.State != currentAppStatus.State {
 		log.Printf("app state changed from %s to %s", currentAppStatus.State, newAppStatus.State)
 		go func() {
-			err := heartbeat.SendAppHeartbeat(store.GetStore())
+			clientset, err := k8sutil.GetClientset()
 			if err != nil {
+				logger.Error(errors.Wrap(err, "failed to get clientset to send heartbeat"))
+				return
+			}
+			if err := heartbeat.SendAppHeartbeat(clientset, store.GetStore()); err != nil {
 				logger.Error(errors.Wrap(err, "failed to send heartbeat"))
 			}
 		}()

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -104,10 +104,12 @@ func GetCurrentAppInfo(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		response.CurrentRelease.HelmReleaseName = helmRelease.Name
-		response.CurrentRelease.HelmReleaseRevision = helmRelease.Version
-		response.CurrentRelease.HelmReleaseNamespace = helmRelease.Namespace
-		response.CurrentRelease.DeployedAt = helmRelease.Info.LastDeployed.Format(time.RFC3339)
+		if helmRelease != nil {
+			response.CurrentRelease.HelmReleaseName = helmRelease.Name
+			response.CurrentRelease.HelmReleaseRevision = helmRelease.Version
+			response.CurrentRelease.HelmReleaseNamespace = helmRelease.Namespace
+			response.CurrentRelease.DeployedAt = helmRelease.Info.LastDeployed.Format(time.RFC3339)
+		}
 	}
 
 	JSON(w, http.StatusOK, response)

--- a/pkg/heartbeat/app.go
+++ b/pkg/heartbeat/app.go
@@ -18,7 +18,12 @@ import (
 func SendAppHeartbeat(sdkStore store.Store) error {
 	license := sdkStore.GetLicense()
 
-	canReport, err := canReport(license)
+	clientset, err := k8sutil.GetClientset()
+	if err != nil {
+		return errors.Wrap(err, "failed to get clientset")
+	}
+
+	canReport, err := canReport(clientset, sdkStore.GetNamespace(), license)
 	if err != nil {
 		return errors.Wrap(err, "failed to check if can report")
 	}

--- a/pkg/heartbeat/app.go
+++ b/pkg/heartbeat/app.go
@@ -13,15 +13,11 @@ import (
 	"github.com/replicatedhq/replicated-sdk/pkg/logger"
 	"github.com/replicatedhq/replicated-sdk/pkg/store"
 	"github.com/replicatedhq/replicated-sdk/pkg/util"
+	"k8s.io/client-go/kubernetes"
 )
 
-func SendAppHeartbeat(sdkStore store.Store) error {
+func SendAppHeartbeat(clientset kubernetes.Interface, sdkStore store.Store) error {
 	license := sdkStore.GetLicense()
-
-	clientset, err := k8sutil.GetClientset()
-	if err != nil {
-		return errors.Wrap(err, "failed to get clientset")
-	}
 
 	canReport, err := canReport(clientset, sdkStore.GetNamespace(), license)
 	if err != nil {

--- a/pkg/heartbeat/heartbeat.go
+++ b/pkg/heartbeat/heartbeat.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/replicated-sdk/pkg/k8sutil"
 	sdklicense "github.com/replicatedhq/replicated-sdk/pkg/license"
 	"github.com/replicatedhq/replicated-sdk/pkg/logger"
 	"github.com/replicatedhq/replicated-sdk/pkg/store"
@@ -63,8 +64,12 @@ func Start() error {
 		}
 
 		go func() {
-			err := SendAppHeartbeat(store.GetStore())
+			clientset, err := k8sutil.GetClientset()
 			if err != nil {
+				logger.Error(errors.Wrap(err, "failed to get clientset to send heartbeat"))
+				return
+			}
+			if err := SendAppHeartbeat(clientset, store.GetStore()); err != nil {
 				logger.Error(errors.Wrap(err, "failed to send heartbeat"))
 			}
 		}()

--- a/pkg/heartbeat/util_test.go
+++ b/pkg/heartbeat/util_test.go
@@ -1,0 +1,182 @@
+package heartbeat
+
+import (
+	"os"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCanReport(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       map[string]string
+		clientset *fake.Clientset
+		namespace string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name: "one pod, one replicaset, revision matches deployment revision",
+			env: map[string]string{
+				"REPLICATED_SDK_POD_NAME": "test-pod",
+			},
+			clientset: fake.NewSimpleClientset(
+				createTestDeployment("replicated-sdk", "test-namespace", "1"),
+				createTestReplicaSet("test-replicaset", "test-namespace", "1"),
+				createTestPod("test-pod", "test-namespace", "test-replicaset"),
+			),
+			namespace: "test-namespace",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name: "one pod, one replicaset, revision does not match deployment revision",
+			env: map[string]string{
+				"REPLICATED_SDK_POD_NAME": "test-pod",
+			},
+			clientset: fake.NewSimpleClientset(
+				createTestDeployment("replicated-sdk", "test-namespace", "2"),
+				createTestReplicaSet("test-replicaset", "test-namespace", "1"),
+				createTestPod("test-pod", "test-namespace", "test-replicaset"),
+			),
+			namespace: "test-namespace",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name: "one pod, two replicasets, revision matches deployment revision",
+			env: map[string]string{
+				"REPLICATED_SDK_POD_NAME": "test-pod",
+			},
+			clientset: fake.NewSimpleClientset(
+				createTestDeployment("replicated-sdk", "test-namespace", "2"),
+				createTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
+				createTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
+				createTestPod("test-pod", "test-namespace", "test-replicaset-bar"),
+			),
+			namespace: "test-namespace",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name: "one pod, two replicasets, revision does not match deployment revision",
+			env: map[string]string{
+				"REPLICATED_SDK_POD_NAME": "test-pod",
+			},
+			clientset: fake.NewSimpleClientset(
+				createTestDeployment("replicated-sdk", "test-namespace", "2"),
+				createTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
+				createTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
+				createTestPod("test-pod", "test-namespace", "test-replicaset-foo"),
+			),
+			namespace: "test-namespace",
+			want:      false,
+			wantErr:   false,
+		},
+		{
+			name: "two pods, two replicasets, revision matches deployment revision",
+			env: map[string]string{
+				"REPLICATED_SDK_POD_NAME": "test-pod-bar",
+			},
+			clientset: fake.NewSimpleClientset(
+				createTestDeployment("replicated-sdk", "test-namespace", "2"),
+				createTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
+				createTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
+				createTestPod("test-pod-foo", "test-namespace", "test-replicaset-foo"),
+				createTestPod("test-pod-bar", "test-namespace", "test-replicaset-bar"),
+			),
+			namespace: "test-namespace",
+			want:      true,
+			wantErr:   false,
+		},
+		{
+			name: "two pods, two replicasets, revision does not match deployment revision",
+			env: map[string]string{
+				"REPLICATED_SDK_POD_NAME": "test-pod-foo",
+			},
+			clientset: fake.NewSimpleClientset(
+				createTestDeployment("replicated-sdk", "test-namespace", "2"),
+				createTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
+				createTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
+				createTestPod("test-pod-foo", "test-namespace", "test-replicaset-foo"),
+				createTestPod("test-pod-bar", "test-namespace", "test-replicaset-bar"),
+			),
+			namespace: "test-namespace",
+			want:      false,
+			wantErr:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				os.Setenv(k, v)
+			}
+
+			defer func() {
+				for k := range tt.env {
+					os.Unsetenv(k)
+				}
+			}()
+
+			got, err := canReport(tt.clientset, tt.namespace, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("canReport() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("canReport() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func createTestDeployment(name string, namespace string, revision string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": revision,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-app"},
+			},
+		},
+	}
+}
+
+func createTestReplicaSet(name string, namespace string, revision string) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": revision,
+			},
+		},
+	}
+}
+
+func createTestPod(name string, namespace string, replicaSetName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "test-app",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       replicaSetName,
+				},
+			},
+		},
+	}
+}

--- a/pkg/heartbeat/util_test.go
+++ b/pkg/heartbeat/util_test.go
@@ -1,7 +1,6 @@
 package heartbeat
 
 import (
-	"os"
 	"testing"
 
 	"github.com/replicatedhq/replicated-sdk/pkg/k8sutil"
@@ -111,14 +110,8 @@ func TestCanReport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
-
-			defer func() {
-				for k := range tt.env {
-					os.Unsetenv(k)
-				}
-			}()
 
 			got, err := canReport(tt.clientset, tt.namespace, nil)
 			if (err != nil) != tt.wantErr {

--- a/pkg/heartbeat/util_test.go
+++ b/pkg/heartbeat/util_test.go
@@ -4,9 +4,7 @@ import (
 	"os"
 	"testing"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/replicatedhq/replicated-sdk/pkg/k8sutil"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -25,9 +23,9 @@ func TestCanReport(t *testing.T) {
 				"REPLICATED_SDK_POD_NAME": "test-pod",
 			},
 			clientset: fake.NewSimpleClientset(
-				createTestDeployment("replicated-sdk", "test-namespace", "1"),
-				createTestReplicaSet("test-replicaset", "test-namespace", "1"),
-				createTestPod("test-pod", "test-namespace", "test-replicaset"),
+				k8sutil.CreateTestDeployment("replicated-sdk", "test-namespace", "1", map[string]string{"app": "test-app"}),
+				k8sutil.CreateTestReplicaSet("test-replicaset", "test-namespace", "1"),
+				k8sutil.CreateTestPod("test-pod", "test-namespace", "test-replicaset", map[string]string{"app": "test-app"}),
 			),
 			namespace: "test-namespace",
 			want:      true,
@@ -39,9 +37,9 @@ func TestCanReport(t *testing.T) {
 				"REPLICATED_SDK_POD_NAME": "test-pod",
 			},
 			clientset: fake.NewSimpleClientset(
-				createTestDeployment("replicated-sdk", "test-namespace", "2"),
-				createTestReplicaSet("test-replicaset", "test-namespace", "1"),
-				createTestPod("test-pod", "test-namespace", "test-replicaset"),
+				k8sutil.CreateTestDeployment("replicated-sdk", "test-namespace", "2", map[string]string{"app": "test-app"}),
+				k8sutil.CreateTestReplicaSet("test-replicaset", "test-namespace", "1"),
+				k8sutil.CreateTestPod("test-pod", "test-namespace", "test-replicaset", map[string]string{"app": "test-app"}),
 			),
 			namespace: "test-namespace",
 			want:      false,
@@ -53,10 +51,10 @@ func TestCanReport(t *testing.T) {
 				"REPLICATED_SDK_POD_NAME": "test-pod",
 			},
 			clientset: fake.NewSimpleClientset(
-				createTestDeployment("replicated-sdk", "test-namespace", "2"),
-				createTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
-				createTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
-				createTestPod("test-pod", "test-namespace", "test-replicaset-bar"),
+				k8sutil.CreateTestDeployment("replicated-sdk", "test-namespace", "2", map[string]string{"app": "test-app"}),
+				k8sutil.CreateTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
+				k8sutil.CreateTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
+				k8sutil.CreateTestPod("test-pod", "test-namespace", "test-replicaset-bar", map[string]string{"app": "test-app"}),
 			),
 			namespace: "test-namespace",
 			want:      true,
@@ -68,10 +66,10 @@ func TestCanReport(t *testing.T) {
 				"REPLICATED_SDK_POD_NAME": "test-pod",
 			},
 			clientset: fake.NewSimpleClientset(
-				createTestDeployment("replicated-sdk", "test-namespace", "2"),
-				createTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
-				createTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
-				createTestPod("test-pod", "test-namespace", "test-replicaset-foo"),
+				k8sutil.CreateTestDeployment("replicated-sdk", "test-namespace", "2", map[string]string{"app": "test-app"}),
+				k8sutil.CreateTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
+				k8sutil.CreateTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
+				k8sutil.CreateTestPod("test-pod", "test-namespace", "test-replicaset-foo", map[string]string{"app": "test-app"}),
 			),
 			namespace: "test-namespace",
 			want:      false,
@@ -83,11 +81,11 @@ func TestCanReport(t *testing.T) {
 				"REPLICATED_SDK_POD_NAME": "test-pod-bar",
 			},
 			clientset: fake.NewSimpleClientset(
-				createTestDeployment("replicated-sdk", "test-namespace", "2"),
-				createTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
-				createTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
-				createTestPod("test-pod-foo", "test-namespace", "test-replicaset-foo"),
-				createTestPod("test-pod-bar", "test-namespace", "test-replicaset-bar"),
+				k8sutil.CreateTestDeployment("replicated-sdk", "test-namespace", "2", map[string]string{"app": "test-app"}),
+				k8sutil.CreateTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
+				k8sutil.CreateTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
+				k8sutil.CreateTestPod("test-pod-foo", "test-namespace", "test-replicaset-foo", map[string]string{"app": "test-app"}),
+				k8sutil.CreateTestPod("test-pod-bar", "test-namespace", "test-replicaset-bar", map[string]string{"app": "test-app"}),
 			),
 			namespace: "test-namespace",
 			want:      true,
@@ -99,11 +97,11 @@ func TestCanReport(t *testing.T) {
 				"REPLICATED_SDK_POD_NAME": "test-pod-foo",
 			},
 			clientset: fake.NewSimpleClientset(
-				createTestDeployment("replicated-sdk", "test-namespace", "2"),
-				createTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
-				createTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
-				createTestPod("test-pod-foo", "test-namespace", "test-replicaset-foo"),
-				createTestPod("test-pod-bar", "test-namespace", "test-replicaset-bar"),
+				k8sutil.CreateTestDeployment("replicated-sdk", "test-namespace", "2", map[string]string{"app": "test-app"}),
+				k8sutil.CreateTestReplicaSet("test-replicaset-foo", "test-namespace", "1"),
+				k8sutil.CreateTestReplicaSet("test-replicaset-bar", "test-namespace", "2"),
+				k8sutil.CreateTestPod("test-pod-foo", "test-namespace", "test-replicaset-foo", map[string]string{"app": "test-app"}),
+				k8sutil.CreateTestPod("test-pod-bar", "test-namespace", "test-replicaset-bar", map[string]string{"app": "test-app"}),
 			),
 			namespace: "test-namespace",
 			want:      false,
@@ -130,53 +128,5 @@ func TestCanReport(t *testing.T) {
 				t.Errorf("canReport() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-func createTestDeployment(name string, namespace string, revision string) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				"deployment.kubernetes.io/revision": revision,
-			},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "test-app"},
-			},
-		},
-	}
-}
-
-func createTestReplicaSet(name string, namespace string, revision string) *appsv1.ReplicaSet {
-	return &appsv1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Annotations: map[string]string{
-				"deployment.kubernetes.io/revision": revision,
-			},
-		},
-	}
-}
-
-func createTestPod(name string, namespace string, replicaSetName string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels: map[string]string{
-				"app": "test-app",
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "apps/v1",
-					Kind:       "ReplicaSet",
-					Name:       replicaSetName,
-				},
-			},
-		},
 	}
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"os"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
@@ -20,11 +19,6 @@ func GetReleaseName() string {
 
 func GetReleaseNamespace() string {
 	return os.Getenv("HELM_RELEASE_NAMESPACE")
-}
-
-func GetReleaseRevision() int {
-	hr, _ := strconv.Atoi(os.Getenv("HELM_RELEASE_REVISION"))
-	return hr
 }
 
 func GetParentChartURL() string {

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage/driver"
 )
 
 func IsHelmManaged() bool {
@@ -48,6 +49,9 @@ func GetRelease(releaseName string) (*release.Release, error) {
 	client := action.NewGet(cfg)
 	release, err := client.Run(releaseName)
 	if err != nil {
+		if errors.Cause(err) == driver.ErrReleaseNotFound {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "failed to get release")
 	}
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -33,6 +33,9 @@ func GetReleaseHistory() ([]*release.Release, error) {
 	client := action.NewHistory(cfg)
 	releases, err := client.Run(GetReleaseName())
 	if err != nil {
+		if errors.Cause(err) == driver.ErrReleaseNotFound {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "failed to list releases")
 	}
 

--- a/pkg/k8sutil/fake.go
+++ b/pkg/k8sutil/fake.go
@@ -1,0 +1,53 @@
+package k8sutil
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateTestDeployment(name string, namespace string, revision string, matchLabels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": revision,
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: matchLabels,
+			},
+		},
+	}
+}
+
+func CreateTestReplicaSet(name string, namespace string, revision string) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"deployment.kubernetes.io/revision": revision,
+			},
+		},
+	}
+}
+
+func CreateTestPod(name string, namespace string, replicaSetName string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       replicaSetName,
+				},
+			},
+		},
+	}
+}

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -16,6 +16,9 @@ func IsDevEnv() bool {
 }
 
 func IsDevLicense(license *kotsv1beta1.License) bool {
+	if license == nil {
+		return false
+	}
 	result, _ := regexp.MatchString(`replicated-app`, license.Spec.Endpoint)
 	return result
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Makes the chart/api work with helm template + kubectl. Uses the deployment's UID as both Replicated and app ID instead of generating new IDs during templating. Will keep using existing IDs for existing installations from the ConfigMap as to not introduce a breaking change. ConfigMap will not be created for fresh installations going forward.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for installing the Helm chart via `helm template` then `kubectl apply` the generated manifests.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
TBD