### PR TITLE
Add missing request headers

### DIFF
--- a/pact/custom_metrics_test.go
+++ b/pact/custom_metrics_test.go
@@ -19,6 +19,7 @@ import (
 func TestSendCustomApplicationMetrics(t *testing.T) {
 	// Happy path only
 
+	channelSequence := int64(1)
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"key1_string":         "val1",
@@ -33,6 +34,7 @@ func TestSendCustomApplicationMetrics(t *testing.T) {
 			LicenseID: "sdk-license-customer-0-license",
 			AppSlug:   "sdk-license-app",
 			Endpoint:  fmt.Sprintf("http://%s:%d", pact.Host, pact.Server.Port),
+			ChannelID: "sdk-license-app-nightly",
 		},
 	}
 
@@ -52,8 +54,10 @@ func TestSendCustomApplicationMetrics(t *testing.T) {
 			WithRequest(dsl.Request{
 				Method: http.MethodPost,
 				Headers: dsl.MapMatcher{
-					"User-Agent":    dsl.String("Replicated-SDK/v0.0.0-unknown"),
-					"Authorization": dsl.String(fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID))))),
+					"User-Agent":                             dsl.String("Replicated-SDK/v0.0.0-unknown"),
+					"Authorization":                          dsl.String(fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", license.Spec.LicenseID, license.Spec.LicenseID))))),
+					"X-Replicated-DownstreamChannelID":       dsl.String(license.Spec.ChannelID),
+					"X-Replicated-DownstreamChannelSequence": dsl.String(fmt.Sprintf("%d", channelSequence)),
 				},
 				Path: dsl.String("/application/custom-metrics"),
 				Body: data,
@@ -69,6 +73,8 @@ func TestSendCustomApplicationMetrics(t *testing.T) {
 			License:               license,
 			LicenseFields:         nil,
 			ReplicatedAppEndpoint: license.Spec.Endpoint,
+			ChannelID:             license.Spec.ChannelID,
+			ChannelSequence:       channelSequence,
 		}
 		if err := store.InitInMemory(storeOptions); err != nil {
 			t.Fatalf("Error on InitInMemory: %v", err)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Test added in https://github.com/replicatedhq/replicated-sdk/pull/79 has missing headers which make the request fail.

Error:

```
[35mreplicated-app_1  |[0m [31m[2023-09-01T19:03:10.571] [ERROR] [TSED] - [39m{
[35mreplicated-app_1  |[0m   method: 'POST',
[35mreplicated-app_1  |[0m   url: '/application/custom-metrics',
[35mreplicated-app_1  |[0m   headers: {
[35mreplicated-app_1  |[0m     version: 'HTTP/1.0',
[35mreplicated-app_1  |[0m     cookie: '',
[35mreplicated-app_1  |[0m     'x-forwarded-for': '127.0.0.1',
[35mreplicated-app_1  |[0m     authorization: 'Basic c2RrLWxpY2Vuc2UtY3VzdG9tZXItMC1saWNlbnNlOnNkay1saWNlbnNlLWN1c3RvbWVyLTAtbGljZW5zZQ==',
[35mreplicated-app_1  |[0m     'user-agent': 'Replicated-SDK/v0.0.0-unknown',
[35mreplicated-app_1  |[0m     host: 'localhost:3000',
[35mreplicated-app_1  |[0m     'content-length': '89',
[35mreplicated-app_1  |[0m     'content-type': 'application/x-www-form-urlencoded'
[35mreplicated-app_1  |[0m   },
[35mreplicated-app_1  |[0m   body: {
[35mreplicated-app_1  |[0m     '{"data":{"key1_string":"val1","key2_int":5,"key3_float":1.5,"key4_numeric_string":"1.6"}}': ''
[35mreplicated-app_1  |[0m   },
[35mreplicated-app_1  |[0m   query: {},
[35mreplicated-app_1  |[0m   params: {},
[35mreplicated-app_1  |[0m   reqId: '467ac4d9e47b49d2889bc3d484cb7a2d',
[35mreplicated-app_1  |[0m   time: 2023-09-01T19:03:10.571Z,
[35mreplicated-app_1  |[0m   duration: 42,
[35mreplicated-app_1  |[0m   error: {
[35mreplicated-app_1  |[0m     name: 'TypeError',
[35mreplicated-app_1  |[0m     message: "Cannot read properties of undefined (reading 'release_sequence')",
[35mreplicated-app_1  |[0m     status: 500,
[35mreplicated-app_1  |[0m     errors: [],
[35mreplicated-app_1  |[0m     stack: "TypeError: Cannot read properties of undefined (reading 'release_sequence')\n" +
[35mreplicated-app_1  |[0m       '    at ChannelStore.getChannel (/src/build/channel/channel_store.js:30:37)\n' +
[35mreplicated-app_1  |[0m       '    at async KotsApplicationAPI.applicationMetrics (/src/build/controllers/KotsApplication.js:72:25)'
[35mreplicated-app_1  |[0m   }
[35mreplicated-app_1  |[0m }
[35mreplicated-app_1  |[0m [32m[2023-09-01T19:03:10.574] [INFO ] [TSED] - [39m{
[35mreplicated-app_1  |[0m   reqId: '467ac4d9e47b49d2889bc3d484cb7a2d',
[35mreplicated-app_1  |[0m   method: 'POST',
[35mreplicated-app_1  |[0m   url: '/application/custom-metrics',
[35mreplicated-app_1  |[0m   duration: 45,
[35mreplicated-app_1  |[0m   time: 2023-09-01T19:03:10.574Z,
[35mreplicated-app_1  |[0m   event: 'request.end',
[35mreplicated-app_1  |[0m   status: 500
[35mreplicated-app_1  |[0m }

```

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE