### PR TITLE
Lookup the dynamic configmap name instead of 'replicated'

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -70,10 +70,6 @@ Is OpenShift
 {{/*
 Resource Names
 */}}
-{{- define "replicated.configMapName" -}}
-  {{ include "replicated.name" . }}
-{{- end -}}
-
 {{- define "replicated.deploymentName" -}}
   {{ include "replicated.name" . }}
 {{- end -}}

--- a/chart/templates/replicated-configmap.yaml
+++ b/chart/templates/replicated-configmap.yaml
@@ -2,7 +2,7 @@
 This is a legacy/deprecated configmap.
 The replicated API will use the deployment uid as the app-id and replicated-id if the configmap does not exist.
 */}}
-{{- $data := (lookup "v1" "ConfigMap" .Release.Namespace "replicated").data }}
+{{- $data := (lookup "v1" "ConfigMap" .Release.Namespace (include "replicated.configMapName" .)).data }}
 {{- if $data }}
 apiVersion: v1
 kind: ConfigMap

--- a/chart/templates/replicated-configmap.yaml
+++ b/chart/templates/replicated-configmap.yaml
@@ -1,17 +1,17 @@
 {{/*
 This is a legacy/deprecated configmap.
-The replicated API will use the deployment uid as the app-id and replicated-id if the configmap does not exist.
+The replicated API will use the deployment uid if the configmap does not exist.
 */}}
-{{- $data := (lookup "v1" "ConfigMap" .Release.Namespace (include "replicated.configMapName" .)).data }}
+{{- $data := (lookup "v1" "ConfigMap" .Release.Namespace "replicated-sdk").data }}
 {{- if $data }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
     {{- include "replicated.labels" . | nindent 4 }}
-  name: {{ include "replicated.configMapName" . }}
+  name: replicated-sdk
   namespace: {{ include "replicated.namespace" . | quote }}
 data:
-  replicated-id: {{ index $data "replicated-id" }}
+  replicated-sdk-id: {{ index $data "replicated-sdk-id" }}
   app-id: {{ index $data "app-id" }}
 {{- end }}

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -67,8 +67,6 @@ spec:
           value: secret # TODO: support other drivers
         - name: REPLICATED_SECRET_NAME
           value: {{ include "replicated.secretName" . }}
-        - name: REPLICATED_CONFIGMAP_NAME
-          value: {{ include "replicated.configMapName" . }}
         - name: REPLICATED_DEPLOYMENT_NAME
           value: {{ include "replicated.deploymentName" . }}
         - name: REPLICATED_CONFIG_FILE

--- a/pkg/util/replicated.go
+++ b/pkg/util/replicated.go
@@ -18,16 +18,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func GetLegacyReplicatedConfigMapName() string {
+	return "replicated-sdk"
+}
+
 func GetReplicatedSecretName() string {
 	if sn := os.Getenv("REPLICATED_SECRET_NAME"); sn != "" {
 		return sn
-	}
-	return "replicated"
-}
-
-func GetReplicatedConfigMapName() string {
-	if cmn := os.Getenv("REPLICATED_CONFIGMAP_NAME"); cmn != "" {
-		return cmn
 	}
 	return "replicated"
 }
@@ -45,9 +42,9 @@ func GetReplicatedAndAppIDs(namespace string) (string, string, error) {
 		return "", "", errors.Wrap(err, "failed to get clientset")
 	}
 
-	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), GetReplicatedConfigMapName(), metav1.GetOptions{})
+	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), GetLegacyReplicatedConfigMapName(), metav1.GetOptions{})
 	if err != nil && !kuberneteserrors.IsNotFound(err) {
-		return "", "", errors.Wrap(err, "failed to get replicated configmap")
+		return "", "", errors.Wrap(err, "failed to get replicated-sdk configmap")
 	}
 
 	replicatedID := ""
@@ -61,7 +58,7 @@ func GetReplicatedAndAppIDs(namespace string) (string, string, error) {
 		replicatedID = string(d.ObjectMeta.UID)
 		appID = string(d.ObjectMeta.UID)
 	} else {
-		replicatedID = cm.Data["replicated-id"]
+		replicatedID = cm.Data["replicated-sdk-id"]
 		appID = cm.Data["app-id"]
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Fixes an issue where the ConfigMap gets deleted even when upgrading from an older installation that still uses the `replicated-sdk` ConfigMap to store the instance IDs.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE