### PR TITLE
chore: Add replicated app info collector and analyser

### DIFF
--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -7,7 +7,7 @@ kind: Secret
 metadata:
   labels:
     {{- include "replicated.labels" . | nindent 4 }}
-    troubleshoot.io/kind: support-bundle
+    troubleshoot.sh/kind: support-bundle
   name: {{ include "replicated.supportBundleName" . }}
   namespace: {{ include "replicated.namespace" . | quote }}
 stringData:
@@ -19,12 +19,12 @@ stringData:
     spec:
       collectors:
         - logs:
-            collectorName: replicated-logs
+            collectorName: replicated-sdk-logs
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
               {{- end }}
-            name: replicated/logs
+            name: replicated-sdk/logs
         - http:
             collectorName: replicated-sdk-app-info
             get:

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -29,10 +29,16 @@ stringData:
             collectorName: replicated-sdk-app-info
             get:
               url: http://replicated-sdk.{{ include "replicated.namespace" . }}:3000/api/v1/app/info
+              headers:
+                User-Agent: "troubleshoot.sh/support-bundle"
+              timeout: 5s
         - http:
             collectorName: replicated-sdk-license-info
             get:
               url: http://replicated-sdk.{{ include "replicated.namespace" . }}:3000/api/v1/license/info
+              headers:
+                User-Agent: "troubleshoot.sh/support-bundle"
+              timeout: 5s
       analyzers:
         - jsonCompare:
             checkName: Replicated SDK App Status

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -23,5 +23,26 @@ stringData:
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
-              {{- end }} 
+              {{- end }}
             name: replicated/logs
+        - http:
+            collectorName: replicated-sdk-app-info
+            get:
+              url: http://replicated-sdk.{{ include "replicated.namespace" . | quote }}:3000/api/v1/app/info
+        - http:
+            collectorName: replicated-sdk-license-info
+            get:
+              url: http://replicated-sdk.{{ include "replicated.namespace" . | quote }}:3000/api/v1/license/info
+      analyzers:
+        - jsonCompare:
+            checkName: Replicated SDK App Status
+            fileName: replicated-sdk-app-info.json
+            path: "appStatus"
+            value: "ready"
+            outcomes:
+              - warn:
+                  when: "false"
+                  message: Replicated SDK App status is not ready.
+              - pass:
+                  when: "true"
+                  message: Replicated SDK App status is not ready.

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -19,30 +19,30 @@ stringData:
     spec:
       collectors:
         - logs:
-            collectorName: replicated-sdk-logs
+            collectorName: replicated-logs
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
               {{- end }}
-            name: replicated-sdk/logs
+            name: replicated/logs
         - http:
-            collectorName: replicated-sdk-app-info
+            collectorName: replicated-app-info
             get:
-              url: http://replicated-sdk.{{ include "replicated.namespace" . }}:3000/api/v1/app/info
+              url: http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/info
               headers:
                 User-Agent: "troubleshoot.sh/support-bundle"
               timeout: 5s
         - http:
-            collectorName: replicated-sdk-license-info
+            collectorName: replicated-license-info
             get:
-              url: http://replicated-sdk.{{ include "replicated.namespace" . }}:3000/api/v1/license/info
+              url: http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/license/info
               headers:
                 User-Agent: "troubleshoot.sh/support-bundle"
               timeout: 5s
       analyzers:
         - jsonCompare:
             checkName: Replicated SDK App Status
-            fileName: replicated-sdk-app-info.json
+            fileName: replicated-app-info.json
             path: "appStatus"
             value: "ready"
             outcomes:

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -28,11 +28,11 @@ stringData:
         - http:
             collectorName: replicated-sdk-app-info
             get:
-              url: http://replicated-sdk.{{ include "replicated.namespace" . | quote }}:3000/api/v1/app/info
+              url: http://replicated-sdk.{{ include "replicated.namespace" . }}:3000/api/v1/app/info
         - http:
             collectorName: replicated-sdk-license-info
             get:
-              url: http://replicated-sdk.{{ include "replicated.namespace" . | quote }}:3000/api/v1/license/info
+              url: http://replicated-sdk.{{ include "replicated.namespace" . }}:3000/api/v1/license/info
       analyzers:
         - jsonCompare:
             checkName: Replicated SDK App Status


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Collects [app info](https://docs.replicated.com/reference/replicated-sdk-apis#get-appinfo) and [license info](https://docs.replicated.com/reference/replicated-sdk-apis#get-licenseinfo) from a running replicated sdk service and stores the information in a support bundle. An analyser has been added to warn whenever the `"appStatus"` is not `"ready"`

You can run `kubectl support-bundle --load-cluster-specs` against a cluster with the service to generate the support bundle

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->