### PR TITLE
Remove authorization header from custom metrics API

### DIFF
--- a/pact/custom_metrics_test.go
+++ b/pact/custom_metrics_test.go
@@ -41,9 +41,6 @@ func TestSendCustomApplicationMetrics(t *testing.T) {
 	clientWriter := httptest.NewRecorder()
 	clientRequest := &http.Request{
 		Body: io.NopCloser(bytes.NewBuffer(customMetricsData)),
-		Header: http.Header{
-			"Authorization": []string{license.Spec.LicenseID},
-		},
 	}
 
 	pactInteraction := func() {

--- a/pkg/handlers/custom_metrics.go
+++ b/pkg/handlers/custom_metrics.go
@@ -20,10 +20,6 @@ type ApplicationMetricsData map[string]interface{}
 
 func SendCustomApplicationMetrics(w http.ResponseWriter, r *http.Request) {
 	license := store.GetStore().GetLicense()
-	if r.Header.Get("Authorization") != license.Spec.LicenseID {
-		w.WriteHeader(http.StatusUnauthorized)
-		return
-	}
 
 	if util.IsAirgap() {
 		JSON(w, http.StatusForbidden, "This request cannot be satisfied in airgap mode")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Removing requirement for authorization header since this only introduces an extra step for apps that don't have license ID.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Custom metrics API no longer requires authorization header.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/1441