### PR TITLE
Ignore empty documents when generating status informers

### DIFF
--- a/pkg/apiserver/bootstrap.go
+++ b/pkg/apiserver/bootstrap.go
@@ -117,13 +117,8 @@ func bootstrap(params APIServerParams) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to get helm release")
 		}
-
 		if helmRelease != nil {
-			i, err := appstate.GenerateStatusInformersForManifest(helmRelease.Manifest)
-			if err != nil {
-				return errors.Wrap(err, "failed to generate status informers")
-			}
-			informers = i
+			informers = appstate.GenerateStatusInformersForManifest(helmRelease.Manifest)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Ignores empty documents when generating status informers so that the API comes up without any issues.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Fixes an issue where the `replicated` Pod/API failed to come up due to the inability to generate status informers if the application contains empty YAML documents, or documents that only have comments.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE