### PR TITLE
add checksum annotation for replicated-secret

### DIFF
--- a/.github/actions/validate-endpoints/action.yml
+++ b/.github/actions/validate-endpoints/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'License fields to validate'
     required: false
     default: '[]'
+  version-label:
+    description: 'Version label to validate'
+    required: false
+    default: ''
   integration-enabled:
     description: 'If integration mode is enabled or not'
     required: false
@@ -87,12 +91,23 @@ runs:
 
     - name: Validate /app/info endpoint
       shell: bash
+      env:
+        VERSION_LABEL: ${{ inputs.version-label }}
       run: |
         appStatus=$(curl -s --fail --show-error localhost:8888/api/v1/app/info | jq -r .appStatus | tr -d '\n')
 
         if [ "$appStatus" != "ready" ]; then
           echo "Expected app status to be 'ready', but is set to '$appStatus'."
           exit 1
+        fi
+
+        if [ -n "$VERSION_LABEL" ]; then
+          versionLabel=$(curl -s --fail --show-error localhost:8888/api/v1/app/info | jq -r .currentRelease.versionLabel | tr -d '\n')
+
+          if [ "$versionLabel" != "$VERSION_LABEL" ]; then
+            echo "Expected version label to be '$VERSION_LABEL', but is '$versionLabel'."
+            exit 1
+          fi
         fi
 
     - name: Validate /app/updates endpoint

--- a/.github/actions/validate-endpoints/action.yml
+++ b/.github/actions/validate-endpoints/action.yml
@@ -91,8 +91,6 @@ runs:
 
     - name: Validate /app/info endpoint
       shell: bash
-      env:
-        VERSION_LABEL: ${{ inputs.version-label }}
       run: |
         appStatus=$(curl -s --fail --show-error localhost:8888/api/v1/app/info | jq -r .appStatus | tr -d '\n')
 
@@ -101,11 +99,12 @@ runs:
           exit 1
         fi
 
-        if [ -n "$VERSION_LABEL" ]; then
+        # TODO: add more validation here if needed
+        if [ -n "${{ inputs.version-label }}" ]; then
           versionLabel=$(curl -s --fail --show-error localhost:8888/api/v1/app/info | jq -r .currentRelease.versionLabel | tr -d '\n')
 
-          if [ "$versionLabel" != "$VERSION_LABEL" ]; then
-            echo "Expected version label to be '$VERSION_LABEL', but is '$versionLabel'."
+          if [ "$versionLabel" != "${{ inputs.version-label }}" ]; then
+            echo "Expected version label to be '${{ inputs.version-label }}', but is '$versionLabel'."
             exit 1
           fi
         fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: replicatedhq/replicated-actions/create-release@v1.1.1
+        uses: replicatedhq/replicated-actions/create-release@v1.5.2
         with:
           app-slug: ${{ env.APP_SLUG }}
           api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}
@@ -266,6 +266,18 @@ jobs:
         with:
           license-id: ${{ env.LICENSE_ID }}
           license-fields: ${{ env.LICENSE_FIELDS }}
+          integration-enabled: 'false'
+
+      - name: Upgrade via Helm as subchart in production mode to a new version
+        run: |
+          helm upgrade test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false --set replicated.versionLabel=1.0.0 --wait --timeout 2m
+
+      - name: Validate endpoints
+        uses: ./.github/actions/validate-endpoints
+        with:
+          license-id: ${{ env.LICENSE_ID }}
+          license-fields: ${{ env.LICENSE_FIELDS }}
+          version-label: '1.0.0'
           integration-enabled: 'false'
 
       - name: Uninstall test-chart via Helm

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -270,7 +270,19 @@ jobs:
 
       - name: Upgrade via Helm as subchart in production mode to a new version
         run: |
+          oldpodname=$(kubectl get pods -l app.kubernetes.io/name=replicated -o jsonpath='{.items[0].metadata.name}')
+          
           helm upgrade test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false --set replicated.versionLabel=1.0.0 --wait --timeout 2m
+
+          COUNTER=1
+          while [ kubectl get pods -l app.kubernetes.io/name=replicated -o jsonpath='{.items[0].metadata.name}' | grep -q $oldpodname ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 60 ]; then
+              echo "Pod did not restart after upgrade"
+              exit 1
+            fi
+            sleep 1
+          done
 
       - name: Validate endpoints
         uses: ./.github/actions/validate-endpoints
@@ -296,6 +308,33 @@ jobs:
           license-id: ${{ env.LICENSE_ID }}
           license-fields: ${{ env.LICENSE_FIELDS }}
           integration-enabled: 'false'
+          deployed-via-kubectl: 'true'
+
+      - name: Upgrade via kubectl as subchart in production mode
+        run: |
+          oldpodname=$(kubectl get pods -l app.kubernetes.io/name=replicated -o jsonpath='{.items[0].metadata.name}')
+
+          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false --set replicated.versionLabel=1.0.0 | kubectl apply -f -
+          kubectl rollout status deployment test-chart --timeout=2m
+          kubectl rollout status deployment replicated --timeout=2m
+
+          COUNTER=1
+          while [ kubectl get pods -l app.kubernetes.io/name=replicated -o jsonpath='{.items[0].metadata.name}' | grep -q $oldpodname ]; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 60 ]; then
+              echo "Pod did not restart after upgrade"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Validate endpoints
+        uses: ./.github/actions/validate-endpoints
+        with:
+          license-id: ${{ env.LICENSE_ID }}
+          license-fields: ${{ env.LICENSE_FIELDS }}
+          integration-enabled: 'false'
+          version-label: '1.0.0'
           deployed-via-kubectl: 'true'
 
       - name: Uninstall test-chart via kubectl

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       {{- include "replicated.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/replicated-secret: {{ include (print $.Template.BasePath "/replicated-secret.yaml") . | sha256sum }}
       labels:
         {{- include "replicated.labels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This PR adds an annotation to the pod spec with the checksum of the `replicated-secret` template to ensure that it's restarted on updates to the configuration.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/90562/instance-insights-app-version-should-update-when-the-chart-is-upgraded

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where data returned from API endpoints and instance reporting was outdated after a chart was upgraded
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE