### PR TITLE
Add extra env to helm template

### DIFF
--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -47,6 +47,9 @@ spec:
           readOnly: true
           subPath: config.yaml
         env:
+        {{- with .Values.extraEnv }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}          
         - name: REPLICATED_NAMESPACE
           valueFrom:
             fieldRef:

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           subPath: config.yaml
         env:
         {{- with .Values.extraEnv }}
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}          
         - name: REPLICATED_NAMESPACE
           valueFrom:

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -43,6 +43,8 @@ service:
   type: ClusterIP
   port: 3000
 
+extraEnv: []
+
 # "integration" mode related values.
 integration:
   licenseID: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
Provide the ability to add extra env variables to the replicated-sdk deployment.

#### Steps to reproduce
Add the following snippet to the helm value file.
```
extraEnv: 
  - name: TEST
    value: 123
```
Run `helm template repli .  --dry-run --debug -f values.yaml.tmpl` and you should see the value added in the replicated-deployment env.

#### Does this PR introduce a user-facing change?
```release-note
A new `extraEnv` attribute was added to the helm values.
```

#### Does this PR require documentation?
NONE