### PR TITLE
Add extra env to helm template

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Create release
         id: create-release
-        uses: replicatedhq/replicated-actions/create-release@v1.1.1
+        uses: replicatedhq/replicated-actions/create-release@v1.5.2
         with:
           app-slug: ${{ env.APP_SLUG }}
           api-token: ${{ secrets.C11Y_MATRIX_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -113,6 +113,19 @@ jobs:
             exit 1
           fi
 
+          cat << EOF >> test-values.yaml
+          extraEnv:
+          - name: TEST_EXTRA_ENV
+            value: test-extra-env
+          EOF
+
+          output=$(helm template oci://ttl.sh/automated-${{ github.run_id }}/replicated --version 0.0.0 --values test-values.yaml)
+
+          if ! echo $output | grep -q 'TEST_EXTRA_ENV'; then
+            printf "user-set extraEnv should exist:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
   create-test-release:
     runs-on: ubuntu-22.04
     needs: [ build-and-push-e2e ]

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -47,6 +47,9 @@ spec:
           readOnly: true
           subPath: config.yaml
         env:
+        {{- with .Values.extraEnv }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}          
         - name: REPLICATED_NAMESPACE
           valueFrom:
             fieldRef:

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           subPath: config.yaml
         env:
         {{- with .Values.extraEnv }}
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}          
         - name: REPLICATED_NAMESPACE
           valueFrom:

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -43,6 +43,8 @@ service:
   type: ClusterIP
   port: 3000
 
+extraEnv: []
+
 # "integration" mode related values.
 integration:
   licenseID: ""


### PR DESCRIPTION
PR from fork: https://github.com/replicatedhq/replicated-sdk/pull/95

#### What this PR does / why we need it:
Provide the ability to add extra env variables to the replicated-sdk deployment.

#### Steps to reproduce
Add the following snippet to the helm value file.
```
extraEnv: 
  - name: TEST
    value: 123
```
Run `helm template repli .  --dry-run --debug -f values.yaml.tmpl` and you should see the value added in the replicated-deployment env.

#### Does this PR introduce a user-facing change?
```release-note
Adds support for adding additional environment variables to the replicated deployment via the `extraEnv` value.
```

#### Does this PR require documentation?
NONE