### PR TITLE
fix pact testing cache in ci

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
+          cache: false
       - uses: replicatedhq/action-install-pact@v1
       - run: make test
       - if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This PR disables go module caching for the `make tests` job because this can cause pact tests not to execute. Caching is enabled by default in `actions/setup-go@v4`, whereas it was not in `v3`.  This can cause failures like the following: https://github.com/replicatedhq/replicated-sdk/actions/runs/6422456432/job/17438965650#step:5:276

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->