### PR TITLE
allow empty status informers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -85,6 +85,11 @@ jobs:
             exit 1
           fi
 
+          if ! echo $output | grep -q 'statusInformers: null'; then
+            printf "default statusInformers should be null:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
           output=$(helm template oci://ttl.sh/automated-${{ github.run_id }}/replicated --version 0.0.0 --set integration.enabled=true)
 
           if ! echo $output | grep -q integration-enabled; then
@@ -121,7 +126,7 @@ jobs:
             exit 1
           fi
 
-          cat << EOF >> test-values.yaml
+          cat << EOF > test-values.yaml
           extraEnv:
           - name: TEST_EXTRA_ENV
             value: test-extra-env
@@ -131,6 +136,17 @@ jobs:
 
           if ! echo $output | grep -q 'TEST_EXTRA_ENV'; then
             printf "user-set extraEnv should exist:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          cat << EOF > test-values.yaml
+          statusInformers: []
+          EOF
+
+          output=$(helm template oci://ttl.sh/automated-${{ github.run_id }}/replicated --version 0.0.0 --values test-values.yaml)
+
+          if ! echo $output | grep -q 'statusInformers: \[\]'; then
+            printf "user-set empty statusInformers should exist:\n\n%s\n\n" "$output"
             exit 1
           fi
 
@@ -296,7 +312,7 @@ jobs:
           helm upgrade test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false --set replicated.versionLabel=1.0.0 --wait --timeout 2m
 
           COUNTER=1
-          while [ kubectl get pods -l app.kubernetes.io/name=replicated -o jsonpath='{.items[0].metadata.name}' | grep -q $oldpodname ]; do
+          while kubectl get pods -l app.kubernetes.io/name=replicated -o jsonpath='{.items[0].metadata.name}' | grep -q $oldpodname; do
             ((COUNTER += 1))
             if [ $COUNTER -gt 60 ]; then
               echo "Pod did not restart after upgrade"
@@ -340,7 +356,7 @@ jobs:
           kubectl rollout status deployment replicated --timeout=2m
 
           COUNTER=1
-          while [ kubectl get pods -l app.kubernetes.io/name=replicated -o jsonpath='{.items[0].metadata.name}' | grep -q $oldpodname ]; do
+          while kubectl get pods -l app.kubernetes.io/name=replicated -o jsonpath='{.items[0].metadata.name}' | grep -q $oldpodname; do
             ((COUNTER += 1))
             if [ $COUNTER -gt 60 ]; then
               echo "Pod did not restart after upgrade"
@@ -361,6 +377,87 @@ jobs:
       - name: Uninstall test-chart via kubectl
         run: |
           helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false | kubectl delete -f -
+          kubectl wait --for=delete deployment/test-chart --timeout=2m
+          kubectl wait --for=delete deployment/replicated --timeout=2m
+
+      # validate status informers
+      - name: Create empty status informers for validation
+        run: |
+          cat << EOF > test-values.yaml
+          replicated:
+            statusInformers: []
+          EOF
+    
+      - name: Install via Helm as subchart in production mode and pass empty status informers
+        run: |
+          helm install test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false -f test-values.yaml --wait --timeout 2m
+
+          COUNTER=1
+          while ! kubectl logs deploy/replicated | grep -qv 'Generated informers from Helm release'; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 60 ]; then
+              echo "Did not receive empty status informers"
+              kubectl logs deploy/replicated
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Upgrade via Helm as subchart in production mode to use default status informers
+        run: |
+          helm upgrade test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false --wait --timeout 2m
+
+          COUNTER=1
+          while ! kubectl logs deploy/replicated | grep -q 'Generated informers from Helm release'; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 60 ]; then
+              echo "Did not receive default status informers"
+              kubectl logs deploy/replicated
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Uninstall test-chart via Helm
+        run: helm uninstall test-chart --wait --timeout 2m
+
+      - name: Install via kubectl as subchart in production mode and pass empty status informers
+        run: |
+          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false -f test-values.yaml | kubectl apply -f -
+          kubectl rollout status deployment test-chart --timeout=2m
+          kubectl rollout status deployment replicated --timeout=2m
+
+          COUNTER=1
+          while ! kubectl logs deploy/replicated | grep -qv 'Generated informers from Helm release'; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 60 ]; then
+              echo "Did not receive empty status informers"
+              kubectl logs deploy/replicated
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Upgrade via kubectl as subchart in production mode to use default status informers
+        run: |
+          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false | kubectl apply -f -
+          kubectl rollout status deployment test-chart --timeout=2m
+          kubectl rollout status deployment replicated --timeout=2m
+
+          COUNTER=1
+          while ! kubectl logs deploy/replicated | grep -qv 'Generated informers from Helm release'; do
+            ((COUNTER += 1))
+            if [ $COUNTER -gt 60 ]; then
+              echo "Did not receive default status informers"
+              kubectl logs deploy/replicated
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Uninstall test-chart via kubectl
+        run: |
+          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false -f test-values.yaml | kubectl delete -f -
           kubectl wait --for=delete deployment/test-chart --timeout=2m
           kubectl wait --for=delete deployment/replicated --timeout=2m
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -393,7 +393,7 @@ jobs:
           helm install test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false -f test-values.yaml --wait --timeout 2m
 
           COUNTER=1
-          while ! kubectl logs deploy/replicated | grep -qv 'Generated informers from Helm release'; do
+          while ! kubectl logs deploy/replicated | grep -qv 'Generating status informers from Helm release'; do
             ((COUNTER += 1))
             if [ $COUNTER -gt 60 ]; then
               echo "Did not receive empty status informers"
@@ -408,7 +408,7 @@ jobs:
           helm upgrade test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false --wait --timeout 2m
 
           COUNTER=1
-          while ! kubectl logs deploy/replicated | grep -q 'Generated informers from Helm release'; do
+          while ! kubectl logs deploy/replicated | grep -q 'Generating status informers from Helm release'; do
             ((COUNTER += 1))
             if [ $COUNTER -gt 60 ]; then
               echo "Did not receive default status informers"
@@ -428,27 +428,10 @@ jobs:
           kubectl rollout status deployment replicated --timeout=2m
 
           COUNTER=1
-          while ! kubectl logs deploy/replicated | grep -qv 'Generated informers from Helm release'; do
+          while ! kubectl logs deploy/replicated | grep -qv 'Generating status informers from Helm release'; do
             ((COUNTER += 1))
             if [ $COUNTER -gt 60 ]; then
               echo "Did not receive empty status informers"
-              kubectl logs deploy/replicated
-              exit 1
-            fi
-            sleep 1
-          done
-
-      - name: Upgrade via kubectl as subchart in production mode to use default status informers
-        run: |
-          helm template test-chart oci://registry.replicated.com/$APP_SLUG/$CHANNEL_SLUG/test-chart --set replicated.integration.enabled=false | kubectl apply -f -
-          kubectl rollout status deployment test-chart --timeout=2m
-          kubectl rollout status deployment replicated --timeout=2m
-
-          COUNTER=1
-          while ! kubectl logs deploy/replicated | grep -qv 'Generated informers from Helm release'; do
-            ((COUNTER += 1))
-            if [ $COUNTER -gt 60 ]; then
-              echo "Did not receive default status informers"
               kubectl logs deploy/replicated
               exit 1
             fi

--- a/chart/templates/replicated-secret.yaml
+++ b/chart/templates/replicated-secret.yaml
@@ -28,6 +28,8 @@ stringData:
     {{- if .Values.statusInformers }}
     statusInformers:
       {{- .Values.statusInformers | toYaml | nindent 6 }}
+    {{- else }}
+    statusInformers: {{ .Values.statusInformers | toYaml }}
     {{- end }}
     replicatedID: {{ .Values.replicatedID | default "" | quote }}
     appID: {{ .Values.appID | default "" | quote }}

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -16,7 +16,7 @@ releaseCreatedAt: ""
 releaseNotes: ""
 versionLabel: ""
 parentChartURL: ""
-statusInformers: []
+statusInformers: null
 replicatedAppEndpoint: ""
 
 serviceAccountName: ""

--- a/pkg/apiserver/bootstrap.go
+++ b/pkg/apiserver/bootstrap.go
@@ -132,17 +132,13 @@ func bootstrap(params APIServerParams) error {
 
 	// if no status informers are provided, generate them from the helm release
 	informers := params.StatusInformers
-	if informers == nil {
-		informers = []appstatetypes.StatusInformerString{}
-		if helm.IsHelmManaged() {
-			helmRelease, err := helm.GetRelease(helm.GetReleaseName())
-			if err != nil {
-				return errors.Wrap(err, "failed to get helm release")
-			}
-			if helmRelease != nil {
-				informers = appstate.GenerateStatusInformersForManifest(helmRelease.Manifest)
-				logger.Infof("Generated informers from Helm release: %v", informers)
-			}
+	if informers == nil && helm.IsHelmManaged() {
+		helmRelease, err := helm.GetRelease(helm.GetReleaseName())
+		if err != nil {
+			return errors.Wrap(err, "failed to get helm release")
+		}
+		if helmRelease != nil {
+			informers = appstate.GenerateStatusInformersForManifest(helmRelease.Manifest)
 		}
 	}
 

--- a/pkg/apiserver/bootstrap.go
+++ b/pkg/apiserver/bootstrap.go
@@ -132,13 +132,17 @@ func bootstrap(params APIServerParams) error {
 
 	// if no status informers are provided, generate them from the helm release
 	informers := params.StatusInformers
-	if informers == nil && helm.IsHelmManaged() {
-		helmRelease, err := helm.GetRelease(helm.GetReleaseName())
-		if err != nil {
-			return errors.Wrap(err, "failed to get helm release")
-		}
-		if helmRelease != nil {
-			informers = appstate.GenerateStatusInformersForManifest(helmRelease.Manifest)
+	if informers == nil {
+		informers = []appstatetypes.StatusInformerString{}
+		if helm.IsHelmManaged() {
+			helmRelease, err := helm.GetRelease(helm.GetReleaseName())
+			if err != nil {
+				return errors.Wrap(err, "failed to get helm release")
+			}
+			if helmRelease != nil {
+				informers = appstate.GenerateStatusInformersForManifest(helmRelease.Manifest)
+				logger.Infof("Generated informers from Helm release: %v", informers)
+			}
 		}
 	}
 

--- a/pkg/apiserver/bootstrap.go
+++ b/pkg/apiserver/bootstrap.go
@@ -132,7 +132,7 @@ func bootstrap(params APIServerParams) error {
 
 	// if no status informers are provided, generate them from the helm release
 	informers := params.StatusInformers
-	if len(informers) == 0 && helm.IsHelmManaged() {
+	if informers == nil && helm.IsHelmManaged() {
 		helmRelease, err := helm.GetRelease(helm.GetReleaseName())
 		if err != nil {
 			return errors.Wrap(err, "failed to get helm release")

--- a/pkg/appstate/util.go
+++ b/pkg/appstate/util.go
@@ -62,6 +62,8 @@ func resourceStatesApplyNew(resourceStates types.ResourceStates, resourceState t
 }
 
 func GenerateStatusInformersForManifest(manifest string) []types.StatusInformerString {
+	logger.Info("Generating status informers from Helm release")
+
 	informers := []types.StatusInformerString{}
 
 	for _, doc := range strings.Split(manifest, "\n---\n") {
@@ -98,8 +100,6 @@ func GenerateStatusInformersForManifest(manifest string) []types.StatusInformerS
 			logger.Debugf("unsupported informer for %s/%s/%s", namespace, kind, name)
 		}
 	}
-
-	logger.Infof("Generating status informers from Helm release: %v", informers)
 
 	return informers
 }

--- a/pkg/appstate/util.go
+++ b/pkg/appstate/util.go
@@ -99,5 +99,7 @@ func GenerateStatusInformersForManifest(manifest string) []types.StatusInformerS
 		}
 	}
 
+	logger.Infof("Generating status informers from Helm release: %v", informers)
+
 	return informers
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This PR allows an empty array of status informers to be explicitly passed to the SDK. Previously if this was the case, the SDK would automatically generate status informers based on the Helm release. The default value for `statusInformers` will still result in them being automatically generated, which maintains existing behavior.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of https://app.shortcut.com/replicated/story/88171/detect-and-configure-the-replicated-sdk-chart-subchart-if-it-s-part-of-the-vendor-s-application

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Status informers will no longer be automatically generated if the user explicitly passes an empty array for the `statusInformers` value.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE