### PR TITLE
feat: allow a user to define tolerations (e.g. multi arch clusters, specific nodes, etc)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -121,7 +121,7 @@ jobs:
             exit 1
           fi
 
-          cat << EOF >> test-values.yaml
+          cat << EOF > test-values.yaml
           extraEnv:
           - name: TEST_EXTRA_ENV
             value: test-extra-env
@@ -133,6 +133,27 @@ jobs:
             printf "user-set extraEnv should exist:\n\n%s\n\n" "$output"
             exit 1
           fi
+          
+          cat << EOF > test-values.yaml 
+          tolerations:
+          - key: "test-toleration-key"
+            operator: "Equal"
+            value: "test-toleration-value"
+            effect: "NoSchedule"
+          EOF
+
+          output=$(helm template oci://ttl.sh/automated-${{ github.run_id }}/replicated --version 0.0.0 --values test-values.yaml)
+
+          if ! echo $output | grep -q 'tolerations:'; then
+            printf "user-set tolerations should exist:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+          if ! echo $output | grep -q 'test-toleration-key'; then
+            printf "user-set tolerations key should exist:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
 
   create-test-release:
     runs-on: ubuntu-22.04

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -29,6 +29,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $podSecurityContext.enabled }}
       securityContext: {{- omit $podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
@@ -51,7 +55,7 @@ spec:
         env:
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}          
+        {{- end }}
         - name: REPLICATED_NAMESPACE
           valueFrom:
             fieldRef:

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -56,3 +56,5 @@ isAirgap: false
 userAgent: ""
 replicatedID: ""
 appID: ""
+
+tolerations: []


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Originally from: https://github.com/replicatedhq/replicated-sdk/pull/103

Adds support for configuring custom tolerations on the SDK deployment.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for adding custom tolerations to the SDK deployment via the `tolerations` value.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/1528