### PR TITLE
Send app status related info only if initialized

### DIFF
--- a/pkg/apiserver/bootstrap.go
+++ b/pkg/apiserver/bootstrap.go
@@ -90,7 +90,7 @@ func bootstrap(params APIServerParams) error {
 		channelName = verifiedLicense.Spec.ChannelName
 	}
 
-	storeOptions := store.InitInMemoryStoreOptions{
+	store.InitInMemory(store.InitInMemoryStoreOptions{
 		License:               verifiedLicense,
 		LicenseFields:         params.LicenseFields,
 		AppName:               params.AppName,
@@ -105,8 +105,7 @@ func bootstrap(params APIServerParams) error {
 		Namespace:             params.Namespace,
 		ReplicatedID:          replicatedID,
 		AppID:                 appID,
-	}
-	store.InitInMemory(storeOptions)
+	})
 
 	isIntegrationModeEnabled, err := integration.IsEnabled(params.Context, clientset, store.GetStore().GetNamespace(), store.GetStore().GetLicense())
 	if err != nil {

--- a/pkg/appstate/operator.go
+++ b/pkg/appstate/operator.go
@@ -106,10 +106,11 @@ func (o *Operator) ApplyAppInformers(args types.AppInformersArgs) {
 	if len(informers) == 0 {
 		// no informers, set state to ready and return
 		defaultReadyStatus := types.AppStatus{
-			AppSlug:   appSlug,
-			UpdatedAt: time.Now(),
-			State:     types.StateReady,
-			Sequence:  sequence,
+			AppSlug:        appSlug,
+			ResourceStates: types.ResourceStates{},
+			UpdatedAt:      time.Now(),
+			State:          types.StateReady,
+			Sequence:       sequence,
 		}
 		if err := o.setAppStatus(defaultReadyStatus); err != nil {
 			log.Printf("error updating app status: %v", err)
@@ -125,7 +126,7 @@ func (o *Operator) setAppStatus(newAppStatus types.AppStatus) error {
 	store.GetStore().SetAppStatus(newAppStatus)
 
 	if newAppStatus.State != currentAppStatus.State {
-		log.Printf("app state changed from %s to %s", currentAppStatus.State, newAppStatus.State)
+		log.Printf("app state changed from %q to %q", currentAppStatus.State, newAppStatus.State)
 		go func() {
 			clientset, err := k8sutil.GetClientset()
 			if err != nil {

--- a/pkg/heartbeat/app.go
+++ b/pkg/heartbeat/app.go
@@ -29,12 +29,10 @@ func SendAppHeartbeat(clientset kubernetes.Interface, sdkStore store.Store) erro
 
 	heartbeatInfo := GetHeartbeatInfo(sdkStore)
 
-	marshalledRS, err := json.Marshal(heartbeatInfo.ResourceStates)
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal resource states")
-	}
-	reqPayload := map[string]interface{}{
-		"resource_states": string(marshalledRS),
+	// build the request body
+	reqPayload := map[string]interface{}{}
+	if err := InjectHeartbeatInfoPayload(reqPayload, heartbeatInfo); err != nil {
+		return errors.Wrap(err, "failed to inject heartbeat info payload")
 	}
 	reqBody, err := json.Marshal(reqPayload)
 	if err != nil {

--- a/pkg/store/memory_store.go
+++ b/pkg/store/memory_store.go
@@ -147,14 +147,6 @@ func (s *InMemoryStore) GetNamespace() string {
 }
 
 func (s *InMemoryStore) GetAppStatus() appstatetypes.AppStatus {
-	if s.appStatus.State == "" {
-		// initialize with none state so that subsequent changes will trigger reporting
-		return appstatetypes.AppStatus{
-			AppSlug:  s.appSlug,
-			Sequence: s.releaseSequence,
-			State:    appstatetypes.StateMissing,
-		}
-	}
 	return s.appStatus
 }
 

--- a/pkg/upstream/replicated.go
+++ b/pkg/upstream/replicated.go
@@ -48,15 +48,12 @@ func GetUpdates(sdkStore store.Store, license *kotsv1beta1.License, currentCurso
 
 	url := fmt.Sprintf("%s://%s/release/%s/pending?%s", u.Scheme, hostname, license.Spec.AppSlug, urlValues.Encode())
 
-	// build the request body
 	heartbeatInfo := heartbeat.GetHeartbeatInfo(sdkStore)
 
-	marshalledRS, err := json.Marshal(heartbeatInfo.ResourceStates)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal resource states")
-	}
-	reqPayload := map[string]interface{}{
-		"resource_states": string(marshalledRS),
+	// build the request body
+	reqPayload := map[string]interface{}{}
+	if err := heartbeat.InjectHeartbeatInfoPayload(reqPayload, heartbeatInfo); err != nil {
+		return nil, errors.Wrap(err, "failed to inject heartbeat info payload")
 	}
 	reqBody, err := json.Marshal(reqPayload)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

When the `replicated` pod restarts, it fetches/sends information to replicated.app while bootstrapping, and it wouldn't have calculated the state of the application yet. We should only send app status related information only if it's been initialized. This is also possible now that our SaaS services support processing partial telemetry data.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE