### PR TITLE
remove app metrics endpoint

### DIFF
--- a/.github/actions/validate-endpoints/action.yml
+++ b/.github/actions/validate-endpoints/action.yml
@@ -142,13 +142,3 @@ runs:
             exit 1
           fi
         fi
-
-    - name: Validate /app/metrics endpoint
-      shell: bash
-      run: |
-        appStatusMetric=$(curl -H 'Authorization: ${{ inputs.license-id }}' -s --fail --show-error localhost:8888/api/v1/app/metrics | jq -r '."X-Replicated-AppStatus"' | tr -d '\n')
-
-        if [ "$appStatusMetric" != "ready" ]; then
-          echo "Expected app status metric 'X-Replicated-AppStatus' to be 'ready', but is set to '$appStatusMetric'."
-          exit 1
-        fi

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -66,7 +66,6 @@ func Start(params APIServerParams) {
 	r.HandleFunc("/api/v1/app/info", handlers.GetCurrentAppInfo).Methods("GET")
 	r.HandleFunc("/api/v1/app/updates", handlers.GetAppUpdates).Methods("GET")
 	r.HandleFunc("/api/v1/app/history", handlers.GetAppHistory).Methods("GET")
-	authRouter.HandleFunc("/api/v1/app/metrics", handlers.GetAppMetrics).Methods("GET")
 	r.HandleFunc("/api/v1/app/custom-metrics", handlers.SendCustomAppMetrics).Methods("POST")
 
 	// integration

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	appstatetypes "github.com/replicatedhq/replicated-sdk/pkg/appstate/types"
 	"github.com/replicatedhq/replicated-sdk/pkg/config"
-	"github.com/replicatedhq/replicated-sdk/pkg/heartbeat"
 	"github.com/replicatedhq/replicated-sdk/pkg/helm"
 	"github.com/replicatedhq/replicated-sdk/pkg/integration"
 	integrationtypes "github.com/replicatedhq/replicated-sdk/pkg/integration/types"
@@ -324,13 +323,6 @@ func mockReleaseToAppRelease(mockRelease integrationtypes.MockRelease) AppReleas
 	}
 
 	return appRelease
-}
-
-func GetAppMetrics(w http.ResponseWriter, r *http.Request) {
-	heartbeatInfo := heartbeat.GetHeartbeatInfo(store.GetStore())
-	headers := heartbeat.GetHeartbeatInfoHeaders(heartbeatInfo)
-
-	JSON(w, http.StatusOK, headers)
 }
 
 func SendCustomAppMetrics(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This PR removes the `/api/v1/app/metrics` endpoint added in https://github.com/replicatedhq/replicated-sdk/pull/101

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://app.shortcut.com/replicated/story/90703/partial-revert-add-an-endpoint-to-the-sdk-where-metrics-can-be-retrieved-adhoc

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->