### PR TITLE
use dockerhub instead of ghcr.io and rename image to replicated-sdk

### DIFF
--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -34,12 +34,12 @@ jobs:
 
       - name: Build replicated image from Dockerfile
         run: |
-          docker build --pull -t replicated/replicated:${{ github.sha }} .
+          docker build --pull -t replicated/replicated-sdk:${{ github.sha }} .
           
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'replicated/replicated:${{ github.sha }}'
+          image-ref: 'replicated/replicated-sdk:${{ github.sha }}'
           format: 'sarif'          
           output: 'trivy-results.sarif'
           ignore-unfixed: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -102,10 +102,15 @@ jobs:
         username: ${{github.actor}}
         password: ${{secrets.GITHUB_TOKEN}}
 
+    - uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USER }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
     - name: Run Package and Publish
       env: 
         REPLICATED_TAG: v${{needs.get-tags.outputs.tag}}
-        REPLICATED_REGISTRY: ghcr.io/replicatedhq # TODO: move to docker.io
+        REPLICATED_REGISTRY: replicated # docker.io/replicated
         REPLICATED_CHART_NAME: replicated
         REPLICATED_CHART_VERSION: ${{needs.get-tags.outputs.tag}}
         REPLICATED_USER_STAGING: ${{secrets.REPLICATED_USER_STAGING}}
@@ -113,8 +118,8 @@ jobs:
         REPLICATED_USER_PROD: ${{secrets.REPLICATED_USER_PROD}}
         REPLICATED_PASS_PROD: ${{secrets.REPLICATED_PASS_PROD}}
       run: |
-        docker build --pull -t "$REPLICATED_REGISTRY/replicated:$REPLICATED_TAG" --build-arg git_tag=${{needs.get-tags.outputs.tag}} .
-        docker push "$REPLICATED_REGISTRY/replicated:$REPLICATED_TAG"
+        docker build --pull -t "$REPLICATED_REGISTRY/replicated-sdk:$REPLICATED_TAG" --build-arg git_tag=${{needs.get-tags.outputs.tag}} .
+        docker push "$REPLICATED_REGISTRY/replicated-sdk:$REPLICATED_TAG"
 
         # TEMPORARY: for backwards compatibility, create another directory to use for the "replicated-sdk" chart
         cp -R chart chart-sdk

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ vet:
 
 .PHONY: build-ttl.sh
 build-ttl.sh:
-	docker build -t ttl.sh/${USER}/replicated:24h .
-	docker push ttl.sh/${USER}/replicated:24h
+	docker build -t ttl.sh/${USER}/replicated-sdk:24h .
+	docker push ttl.sh/${USER}/replicated-sdk:24h
 
 	make -C chart build-ttl.sh
 

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 images:
-  replicated: ${REPLICATED_REGISTRY}/replicated:${REPLICATED_TAG}
+  replicated: ${REPLICATED_REGISTRY}/replicated-sdk:${REPLICATED_TAG}
 
 license: ""
 licenseFields: ""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Uses dockerhub to host the replicated-sdk image instead of ghcr.io and renames the image from `replicated` to `replicated-sdk`

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of [SC-89414](https://app.shortcut.com/replicated/story/89414/ability-for-the-sdk-api-to-handle-being-installed-in-a-kots-airgap-scenario)

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE