### PR TITLE
images.replicated-sdk instead of images.replicated

### DIFF
--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           secretName: {{ include "replicated.secretName" . }}
       containers:
       - name: replicated
-        image: {{ index .Values.images "replicated" }}
+        image: {{ index .Values.images "replicated-sdk" }}
         imagePullPolicy: IfNotPresent
         {{- if .Values.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 10 }}

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 images:
-  replicated: ${REPLICATED_REGISTRY}/replicated-sdk:${REPLICATED_TAG}
+  replicated-sdk: ${REPLICATED_REGISTRY}/replicated-sdk:${REPLICATED_TAG}
 
 license: ""
 licenseFields: ""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Since the image was renamed to `replicated-sdk`, it would make more sense the Helm value is named as such.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Renames the `images.replicated` Helm value to `images.replicated-sdk`.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE