### PR TITLE
add namespace input to validate-endpoints action

### DIFF
--- a/.github/actions/validate-endpoints/action.yml
+++ b/.github/actions/validate-endpoints/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'If the chart was deployed in airgap mode'
     required: false
     default: 'false'
+  namespace:
+    description: 'Namespace that the Replicated SDK is deployed in'
+    required: false
+    default: 'default'
 runs:
   using: "composite"
   steps:
@@ -34,7 +38,7 @@ runs:
       shell: bash
       run: |
         kill -9 $(sudo lsof -t -i:8888) 2>/dev/null || true
-        kubectl port-forward svc/replicated 8888:3000 &
+        kubectl port-forward -n "${{ inputs.namespace }}" svc/replicated 8888:3000 &
         sleep 5
 
     - name: Validate integration status

--- a/.github/actions/validate-endpoints/action.yml
+++ b/.github/actions/validate-endpoints/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
     default: 'false'
   namespace:
-    description: 'Namespace that the Replicated SDK is deployed in'
+    description: 'Namespace that the Replicated API is deployed in'
     required: false
     default: 'default'
 runs:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Adds a `namespace` input to the `validate-endpoints` GH action to specify the namespace that the Replicated SDK is deployed to. Defaults to `default`.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->