### PR TITLE
Return false for integration.IsEnabled if key unset in replicated secret

### DIFF
--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -38,7 +38,7 @@ func IsEnabled(ctx context.Context, clientset kubernetes.Interface, namespace st
 
 	v, ok := secret.Data[integrationEnabledKey]
 	if !ok || len(v) == 0 {
-		return true, nil
+		return false, nil
 	}
 
 	enabled, _ := strconv.ParseBool(string(v))

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -136,7 +136,7 @@ func TestIntegration_IsEnabled(t *testing.T) {
 					},
 				},
 			},
-			want:    true,
+			want:    false,
 			wantErr: false,
 		},
 		{
@@ -163,7 +163,7 @@ func TestIntegration_IsEnabled(t *testing.T) {
 					},
 				},
 			},
-			want:    true,
+			want:    false,
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

The logic here appears to be flipped - if the integration key is absent or empty, I would guess that means "false"


#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

- Do any standard SDK install (i.e. not in integration mode)
- curl the /api/v1/app/info endpoint via your desired route (exec, port-forward, etc)
- receive mock data with incorrect `helmChartURL` and `currentRelease`

```
{
  "appSlug": "slackernews-dexter-s-version",
  "appName": "SlackerNews (Dexter's Version)",
  "appStatus": "ready",
  "helmChartURL": "oci://registry.replicated.com/dev-app/dev-channel/dev-parent-chart",
  "currentRelease": {
    "versionLabel": "0.1.3",
    "releaseNotes": "release notes 0.1.3",
    "createdAt": "2023-05-23T20:58:07Z",
    "deployedAt": "2023-05-23T21:58:07Z",
    "helmReleaseName": "dev-parent-chart",
    "helmReleaseRevision": 3,
    "helmReleaseNamespace": "default"
  }
}
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fix a bug in the evaluation of "integration mode" for `/api/v1/app/info` and other related endpoints
```

#### Does this PR require documentation?

No, bug fix