### PR TITLE
add default fsGroup and supplementalGroups to podSecurityContext

### DIFF
--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -6,6 +6,14 @@
   {{ if eq ($podSecurityContext.runAsGroup | int) 1001 }}
     {{- $_ := unset $podSecurityContext "runAsGroup" }}
   {{- end }}
+  {{ if eq ($podSecurityContext.fsGroup | int) 1001 }}
+    {{- $_ := unset $podSecurityContext "fsGroup" }}
+  {{- end }}
+  {{ if eq ($podSecurityContext.supplementalGroups | len) 1 }}
+    {{ if eq (index $podSecurityContext.supplementalGroups 0 | int) 1001 }}
+      {{- $_ := unset $podSecurityContext "supplementalGroups" }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -36,6 +36,8 @@ podSecurityContext:
   enabled: true
   runAsUser: 1001
   runAsGroup: 1001
+  fsGroup: 1001
+  supplementalGroups: [1001]
   seccompProfile:
     type: "RuntimeDefault"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This PR adds default values for `fsGroup` and `supplementalGroups` to the SDK pod security context. The goal is to provide more out-of-the-box support for admission controllers that may require these fields be set.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds `fsGroup` and `supplementalGroups` to the default PodSecurityContext for the Replicated SDK deployment.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE