### PR TITLE
Adds SLSA attestation and provenance jobs

### DIFF
--- a/.github/actions/build-push-action/action.yml
+++ b/.github/actions/build-push-action/action.yml
@@ -23,6 +23,13 @@ inputs:
     default: ''
     required: false
 
+outputs:
+  # The digest of the published container image is required for the provenance job
+  digest:
+    value: ${{ steps.apko-publish.outputs.digest }}
+    description: |
+      The digest of the published container image.
+
 runs:
   using: "composite"
   steps:
@@ -45,6 +52,7 @@ runs:
         cache-dir: ${{ steps.cache-dir.outputs.cache_dir }}
 
     - uses: chainguard-images/actions/apko-publish@main
+      id: apko-publish
       with:
         config: ${{ inputs.context }}/apko.yaml
         tag: ${{ inputs.image-name }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -127,56 +127,52 @@ jobs:
           console.log(digest);
           core.setOutput("digest", digest);
 
-    - name: Run Package and Publish
-      env: 
-        REPLICATED_TAG: v${{needs.get-tags.outputs.tag}}
-        # StormsChangeMe
-        # REPLICATED_REGISTRY: replicated # docker.io/replicated
-        REPLICATED_REGISTRY: st0rmz1 # docker.io/replicated
-        REPLICATED_CHART_NAME: replicated
-        REPLICATED_CHART_VERSION: ${{needs.get-tags.outputs.tag}}
-        REPLICATED_USER_STAGING: ${{secrets.REPLICATED_USER_STAGING}}
-        REPLICATED_PASS_STAGING: ${{secrets.REPLICATED_PASS_STAGING}}
-        REPLICATED_USER_PROD: ${{secrets.REPLICATED_USER_PROD}}
-        REPLICATED_PASS_PROD: ${{secrets.REPLICATED_PASS_PROD}}
-      run: |
-        # TEMPORARY: for backwards compatibility, create another directory to use for the "replicated-sdk" chart
-        cp -R chart chart-sdk
-
-        cd chart
-        envsubst < Chart.yaml.tmpl > Chart.yaml
-        envsubst < values.yaml.tmpl > values.yaml
-        rm -f *.tmpl
-
-        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
-
-        # StormsChangeMe Temp disable staging test
-        # echo pushing ${CHART_NAME} to staging
-        # helm registry login registry.staging.replicated.com --username $REPLICATED_USER_STAGING --password $REPLICATED_PASS_STAGING
-        # helm push $CHART_NAME oci://registry.staging.replicated.com/library
-
-        echo pushing ${CHART_NAME} to production
-        helm registry login registry.replicated.com --username $REPLICATED_USER_PROD --password $REPLICATED_PASS_PROD
-        helm push $CHART_NAME oci://registry.replicated.com/library
-
-        # TEMPORARY: for backwards compatibility, package and push chart with "replicated-sdk" name
-        cd ../chart-sdk
-        REPLICATED_CHART_NAME=replicated-sdk
-        envsubst < Chart.yaml.tmpl > Chart.yaml
-        envsubst < values.yaml.tmpl > values.yaml
-        rm -f *.tmpl
-
-        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
-
-        # StormsChangeMe Temp disable staging test
-        # echo pushing ${CHART_NAME} to staging
-        # helm push $CHART_NAME oci://registry.staging.replicated.com/library
-
-        echo pushing ${CHART_NAME} to production
-        helm push $CHART_NAME oci://registry.replicated.com/library
-
-    - name: Pact record-release
-      run: make record-release
+#    - name: Run Package and Publish
+#      env: 
+#        REPLICATED_TAG: v${{needs.get-tags.outputs.tag}}
+#        REPLICATED_REGISTRY: replicated # docker.io/replicated
+#        REPLICATED_CHART_NAME: replicated
+#        REPLICATED_CHART_VERSION: ${{needs.get-tags.outputs.tag}}
+#        REPLICATED_USER_STAGING: ${{secrets.REPLICATED_USER_STAGING}}
+#        REPLICATED_PASS_STAGING: ${{secrets.REPLICATED_PASS_STAGING}}
+#        REPLICATED_USER_PROD: ${{secrets.REPLICATED_USER_PROD}}
+#        REPLICATED_PASS_PROD: ${{secrets.REPLICATED_PASS_PROD}}
+#      run: |
+#        # TEMPORARY: for backwards compatibility, create another directory to use for the "replicated-sdk" chart
+#        cp -R chart chart-sdk
+#
+#        cd chart
+#        envsubst < Chart.yaml.tmpl > Chart.yaml
+#        envsubst < values.yaml.tmpl > values.yaml
+#        rm -f *.tmpl
+#
+#        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
+#
+#        echo pushing ${CHART_NAME} to staging
+#        helm registry login registry.staging.replicated.com --username $REPLICATED_USER_STAGING --password $REPLICATED_PASS_STAGING
+#        helm push $CHART_NAME oci://registry.staging.replicated.com/library
+#
+#        echo pushing ${CHART_NAME} to production
+#        helm registry login registry.replicated.com --username $REPLICATED_USER_PROD --password $REPLICATED_PASS_PROD
+#        helm push $CHART_NAME oci://registry.replicated.com/library
+#
+#        # TEMPORARY: for backwards compatibility, package and push chart with "replicated-sdk" name
+#        cd ../chart-sdk
+#        REPLICATED_CHART_NAME=replicated-sdk
+#        envsubst < Chart.yaml.tmpl > Chart.yaml
+#        envsubst < values.yaml.tmpl > values.yaml
+#        rm -f *.tmpl
+#
+#        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
+#
+#        echo pushing ${CHART_NAME} to staging
+#        helm push $CHART_NAME oci://registry.staging.replicated.com/library
+#
+#        echo pushing ${CHART_NAME} to production
+#        helm push $CHART_NAME oci://registry.replicated.com/library
+#
+#    - name: Pact record-release
+#      run: make record-release
 
   provenance: 
     # This job is responsible for generating the SLSA provenance for the image that was pushed to the registry.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -108,9 +108,7 @@ jobs:
       id: build-push-action
       with:
         context: deploy
-        # StormsChangeMe
-        # image-name: index.docker.io/replicated/replicated-sdk:v${{needs.get-tags.outputs.tag}}
-        image-name: index.docker.io/st0rmz1/replicated-sdk:v${{needs.get-tags.outputs.tag}}
+        image-name: index.docker.io/replicated/replicated-sdk:v${{needs.get-tags.outputs.tag}}
         git-tag: v${{needs.get-tags.outputs.tag}}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -127,52 +125,52 @@ jobs:
           console.log(digest);
           core.setOutput("digest", digest);
 
-#    - name: Run Package and Publish
-#      env: 
-#        REPLICATED_TAG: v${{needs.get-tags.outputs.tag}}
-#        REPLICATED_REGISTRY: replicated # docker.io/replicated
-#        REPLICATED_CHART_NAME: replicated
-#        REPLICATED_CHART_VERSION: ${{needs.get-tags.outputs.tag}}
-#        REPLICATED_USER_STAGING: ${{secrets.REPLICATED_USER_STAGING}}
-#        REPLICATED_PASS_STAGING: ${{secrets.REPLICATED_PASS_STAGING}}
-#        REPLICATED_USER_PROD: ${{secrets.REPLICATED_USER_PROD}}
-#        REPLICATED_PASS_PROD: ${{secrets.REPLICATED_PASS_PROD}}
-#      run: |
-#        # TEMPORARY: for backwards compatibility, create another directory to use for the "replicated-sdk" chart
-#        cp -R chart chart-sdk
-#
-#        cd chart
-#        envsubst < Chart.yaml.tmpl > Chart.yaml
-#        envsubst < values.yaml.tmpl > values.yaml
-#        rm -f *.tmpl
-#
-#        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
-#
-#        echo pushing ${CHART_NAME} to staging
-#        helm registry login registry.staging.replicated.com --username $REPLICATED_USER_STAGING --password $REPLICATED_PASS_STAGING
-#        helm push $CHART_NAME oci://registry.staging.replicated.com/library
-#
-#        echo pushing ${CHART_NAME} to production
-#        helm registry login registry.replicated.com --username $REPLICATED_USER_PROD --password $REPLICATED_PASS_PROD
-#        helm push $CHART_NAME oci://registry.replicated.com/library
-#
-#        # TEMPORARY: for backwards compatibility, package and push chart with "replicated-sdk" name
-#        cd ../chart-sdk
-#        REPLICATED_CHART_NAME=replicated-sdk
-#        envsubst < Chart.yaml.tmpl > Chart.yaml
-#        envsubst < values.yaml.tmpl > values.yaml
-#        rm -f *.tmpl
-#
-#        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
-#
-#        echo pushing ${CHART_NAME} to staging
-#        helm push $CHART_NAME oci://registry.staging.replicated.com/library
-#
-#        echo pushing ${CHART_NAME} to production
-#        helm push $CHART_NAME oci://registry.replicated.com/library
-#
-#    - name: Pact record-release
-#      run: make record-release
+    - name: Run Package and Publish
+      env: 
+        REPLICATED_TAG: v${{needs.get-tags.outputs.tag}}
+        REPLICATED_REGISTRY: replicated # docker.io/replicated
+        REPLICATED_CHART_NAME: replicated
+        REPLICATED_CHART_VERSION: ${{needs.get-tags.outputs.tag}}
+        REPLICATED_USER_STAGING: ${{secrets.REPLICATED_USER_STAGING}}
+        REPLICATED_PASS_STAGING: ${{secrets.REPLICATED_PASS_STAGING}}
+        REPLICATED_USER_PROD: ${{secrets.REPLICATED_USER_PROD}}
+        REPLICATED_PASS_PROD: ${{secrets.REPLICATED_PASS_PROD}}
+      run: |
+        # TEMPORARY: for backwards compatibility, create another directory to use for the "replicated-sdk" chart
+        cp -R chart chart-sdk
+
+        cd chart
+        envsubst < Chart.yaml.tmpl > Chart.yaml
+        envsubst < values.yaml.tmpl > values.yaml
+        rm -f *.tmpl
+
+        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
+
+        echo pushing ${CHART_NAME} to staging
+        helm registry login registry.staging.replicated.com --username $REPLICATED_USER_STAGING --password $REPLICATED_PASS_STAGING
+        helm push $CHART_NAME oci://registry.staging.replicated.com/library
+
+        echo pushing ${CHART_NAME} to production
+        helm registry login registry.replicated.com --username $REPLICATED_USER_PROD --password $REPLICATED_PASS_PROD
+        helm push $CHART_NAME oci://registry.replicated.com/library
+
+        # TEMPORARY: for backwards compatibility, package and push chart with "replicated-sdk" name
+        cd ../chart-sdk
+        REPLICATED_CHART_NAME=replicated-sdk
+        envsubst < Chart.yaml.tmpl > Chart.yaml
+        envsubst < values.yaml.tmpl > values.yaml
+        rm -f *.tmpl
+
+        export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
+
+        echo pushing ${CHART_NAME} to staging
+        helm push $CHART_NAME oci://registry.staging.replicated.com/library
+
+        echo pushing ${CHART_NAME} to production
+        helm push $CHART_NAME oci://registry.replicated.com/library
+
+    - name: Pact record-release
+      run: make record-release
 
   provenance: 
     # This job is responsible for generating the SLSA provenance for the image that was pushed to the registry.
@@ -186,9 +184,7 @@ jobs:
     if: success() && needs.package-and-publish.result == 'success'
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with: 
-      # StormsChangeMe
-      # image: index.docker.io/replicated/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
-      image: index.docker.io/st0rmz1/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
+      image: index.docker.io/replicated/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
       digest: ${{ needs.package-and-publish.outputs.digest }}
     secrets:
       registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -105,6 +105,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - uses: ./.github/actions/build-push-action
+      id: build-push-action
       with:
         context: deploy
         # StormsChangeMe

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -109,7 +109,7 @@ jobs:
         context: deploy
         # StormsChangeMe
         # image-name: index.docker.io/replicated/replicated-sdk:v${{needs.get-tags.outputs.tag}}
-        image-name: index.docker.io/St0rmz1/replicated-sdk:v${{needs.get-tags.outputs.tag}}
+        image-name: index.docker.io/st0rmz1/replicated-sdk:v${{needs.get-tags.outputs.tag}}
         git-tag: v${{needs.get-tags.outputs.tag}}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -131,7 +131,7 @@ jobs:
         REPLICATED_TAG: v${{needs.get-tags.outputs.tag}}
         # StormsChangeMe
         # REPLICATED_REGISTRY: replicated # docker.io/replicated
-        REPLICATED_REGISTRY: St0rmz1 # docker.io/replicated
+        REPLICATED_REGISTRY: st0rmz1 # docker.io/replicated
         REPLICATED_CHART_NAME: replicated
         REPLICATED_CHART_VERSION: ${{needs.get-tags.outputs.tag}}
         REPLICATED_USER_STAGING: ${{secrets.REPLICATED_USER_STAGING}}
@@ -189,7 +189,7 @@ jobs:
     with: 
       # StormsChangeMe
       # image: index.docker.io/replicated/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
-      image: index.docker.io/St0rmz1/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
+      image: index.docker.io/st0rmz1/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
       digest: ${{ needs.package-and-publish.outputs.digest }}
     secrets:
       registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -183,7 +183,7 @@ jobs:
     if: success() && needs.package-and-publish.result == 'success'
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with: 
-      image: index.docker.io/st0rmz1/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
+      image: index.docker.io/replicated/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
       digest: ${{ needs.package-and-publish.outputs.digest }}
     secrets:
       registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -149,9 +149,10 @@ jobs:
 
         export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
 
-        echo pushing ${CHART_NAME} to staging
-        helm registry login registry.staging.replicated.com --username $REPLICATED_USER_STAGING --password $REPLICATED_PASS_STAGING
-        helm push $CHART_NAME oci://registry.staging.replicated.com/library
+        # StormsChangeMe Temp disable staging test
+        # echo pushing ${CHART_NAME} to staging
+        # helm registry login registry.staging.replicated.com --username $REPLICATED_USER_STAGING --password $REPLICATED_PASS_STAGING
+        # helm push $CHART_NAME oci://registry.staging.replicated.com/library
 
         echo pushing ${CHART_NAME} to production
         helm registry login registry.replicated.com --username $REPLICATED_USER_PROD --password $REPLICATED_PASS_PROD
@@ -166,8 +167,9 @@ jobs:
 
         export CHART_NAME=`helm package . | rev | cut -d/ -f1 | rev`
 
-        echo pushing ${CHART_NAME} to staging
-        helm push $CHART_NAME oci://registry.staging.replicated.com/library
+        # StormsChangeMe Temp disable staging test
+        # echo pushing ${CHART_NAME} to staging
+        # helm push $CHART_NAME oci://registry.staging.replicated.com/library
 
         echo pushing ${CHART_NAME} to production
         helm push $CHART_NAME oci://registry.replicated.com/library

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,6 +86,9 @@ jobs:
       - get-tags
       - make-tests
       - make-build
+    outputs:
+      # digest of the image pushed to the registry. This is used for the provenance generation
+      digest: ${{ steps.trim-and-save-digest.outputs.digest }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -108,6 +111,18 @@ jobs:
         git-tag: v${{needs.get-tags.outputs.tag}}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    
+    - name: 'Trim and Save Digest'
+    # build-push-action outputs the full image name and digest, but we need to save just the sha256 part
+      id: trim-and-save-digest
+      uses: actions/github-script@v7
+      with:
+       script: |
+          const fullDigest = "${{ steps.build-push-action.outputs.digest }}";
+          const digest = fullDigest.split('@')[1];
+          console.log(fullDigest);
+          console.log(digest);
+          core.setOutput("digest", digest);
 
     - name: Run Package and Publish
       env: 
@@ -155,3 +170,22 @@ jobs:
 
     - name: Pact record-release
       run: make record-release
+
+  provenance: 
+    # This job is responsible for generating the SLSA provenance for the image that was pushed to the registry.
+    needs:
+      - package-and-publish
+      - get-tags
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: success() && needs.package-and-publish.result == 'success'
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
+    with: 
+      image: index.docker.io/st0rmz1/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
+      digest: ${{ needs.package-and-publish.outputs.digest }}
+    secrets:
+      registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      registry-username: ${{ secrets.DOCKERHUB_USER }}
+        

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -107,7 +107,9 @@ jobs:
     - uses: ./.github/actions/build-push-action
       with:
         context: deploy
-        image-name: index.docker.io/replicated/replicated-sdk:v${{needs.get-tags.outputs.tag}}
+        # StormsChangeMe
+        # image-name: index.docker.io/replicated/replicated-sdk:v${{needs.get-tags.outputs.tag}}
+        image-name: index.docker.io/St0rmz1/replicated-sdk:v${{needs.get-tags.outputs.tag}}
         git-tag: v${{needs.get-tags.outputs.tag}}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -127,7 +129,9 @@ jobs:
     - name: Run Package and Publish
       env: 
         REPLICATED_TAG: v${{needs.get-tags.outputs.tag}}
-        REPLICATED_REGISTRY: replicated # docker.io/replicated
+        # StormsChangeMe
+        # REPLICATED_REGISTRY: replicated # docker.io/replicated
+        REPLICATED_REGISTRY: St0rmz1 # docker.io/replicated
         REPLICATED_CHART_NAME: replicated
         REPLICATED_CHART_VERSION: ${{needs.get-tags.outputs.tag}}
         REPLICATED_USER_STAGING: ${{secrets.REPLICATED_USER_STAGING}}
@@ -183,7 +187,9 @@ jobs:
     if: success() && needs.package-and-publish.result == 'success'
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with: 
-      image: index.docker.io/replicated/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
+      # StormsChangeMe
+      # image: index.docker.io/replicated/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
+      image: index.docker.io/St0rmz1/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
       digest: ${{ needs.package-and-publish.outputs.digest }}
     secrets:
       registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
New feature request to create attestations and provenance using the SLSA framework.

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Modifications to the workflow and actions.
- modifies the build-push-action to return the image hash
- image hash is used in the provenance job
- Adds the 'provenance' job which calls the slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
- generator_container_slsa3 creates the attestations, adds the .att files to dockerhub and updates sigstor

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```
Adds provenance and attestations based on the SLSA framework.
[Supply-chain Levels for Software Artifacts](https://slsa.dev/), or SLSA (salsa), is a security framework, a checklist of standards and controls to prevent tampering, improve integrity, and secure packages and infrastructure in your projects, businesses or enterprises.

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
Yes, this will require documentation, but the docs have not been created yet. I will create the docs once we create the PR to the base repo.

