### PR TITLE
Adds SLSA generation at the end of the publish workflow

### DIFF
--- a/.github/actions/build-push-action/action.yml
+++ b/.github/actions/build-push-action/action.yml
@@ -23,6 +23,13 @@ inputs:
     default: ''
     required: false
 
+outputs:
+  # The digest of the published container image is required for the provenance job
+  digest:
+    value: ${{ steps.apko-publish.outputs.digest }}
+    description: |
+      The digest of the published container image.
+
 runs:
   using: "composite"
   steps:
@@ -45,6 +52,7 @@ runs:
         cache-dir: ${{ steps.cache-dir.outputs.cache_dir }}
 
     - uses: chainguard-images/actions/apko-publish@main
+      id: apko-publish
       with:
         config: ${{ inputs.context }}/apko.yaml
         tag: ${{ inputs.image-name }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -121,8 +121,6 @@ jobs:
        script: |
           const fullDigest = "${{ steps.build-push-action.outputs.digest }}";
           const digest = fullDigest.split('@')[1];
-          console.log(fullDigest);
-          console.log(digest);
           core.setOutput("digest", digest);
 
     - name: Run Package and Publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,6 +86,9 @@ jobs:
       - get-tags
       - make-tests
       - make-build
+    outputs:
+      # digest of the image pushed to the registry. This is used for the provenance generation
+      digest: ${{ steps.trim-and-save-digest.outputs.digest }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -102,12 +105,25 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - uses: ./.github/actions/build-push-action
+      id: build-push-action
       with:
         context: deploy
         image-name: index.docker.io/replicated/replicated-sdk:v${{needs.get-tags.outputs.tag}}
         git-tag: v${{needs.get-tags.outputs.tag}}
         registry-username: ${{ secrets.DOCKERHUB_USER }}
         registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    
+    - name: 'Trim and Save Digest'
+    # build-push-action outputs the full image name and digest, but we need to save just the sha256 part
+      id: trim-and-save-digest
+      uses: actions/github-script@v7
+      with:
+       script: |
+          const fullDigest = "${{ steps.build-push-action.outputs.digest }}";
+          const digest = fullDigest.split('@')[1];
+          console.log(fullDigest);
+          console.log(digest);
+          core.setOutput("digest", digest);
 
     - name: Run Package and Publish
       env: 
@@ -155,3 +171,22 @@ jobs:
 
     - name: Pact record-release
       run: make record-release
+
+  provenance: 
+    # This job is responsible for generating the SLSA provenance for the image that was pushed to the registry.
+    needs:
+      - package-and-publish
+      - get-tags
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: success() && needs.package-and-publish.result == 'success'
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
+    with: 
+      image: index.docker.io/replicated/replicated-sdk:v${{ needs.get-tags.outputs.tag }}
+      digest: ${{ needs.package-and-publish.outputs.digest }}
+    secrets:
+      registry-password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      registry-username: ${{ secrets.DOCKERHUB_USER }}
+        


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This PR adds SLSA generation for the replicated SDK image.
Supply-chain Levels for Software Artifacts, or SLSA ("salsa").


#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # No related issues in the github issue tracker

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

This uses the reussable workflow from slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0


#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
N/A

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

Adds SLSA generation for the replicated SDK image. SLSA is the Supply-chain Levels for Software Artifacts ( Pronounced "salsa").

For example, you will be able to validate the attestation via

cosign download attestation replicated/replicated-sdk:VERSION | jq -r .payload | base64 -d | jq

or
search Sigstor using Rekor at https://search.sigstore.dev/

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
Yes