### PR TITLE
Quote namespaces in the support bundle spec

### DIFF
--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -40,17 +40,17 @@ stringData:
                 User-Agent: "troubleshoot.sh/support-bundle"
               timeout: 5s
         - secret:
-            namespace: {{ include "replicated.namespace" . }}
+            namespace: {{ include "replicated.namespace" . | quote }}
             name: replicated-instance-report
             includeValue: true
             key: report
         - secret:
-            namespace: {{ include "replicated.namespace" . }}
+            namespace: {{ include "replicated.namespace" . | quote }}
             name: replicated-custom-app-metrics-report
             includeValue: true
             key: report
         - secret:
-            namespace: {{ include "replicated.namespace" . }}
+            namespace: {{ include "replicated.namespace" . | quote }}
             name: replicated-meta-data
             includeValue: true
             key: instance-tag-data 
@@ -66,4 +66,4 @@ stringData:
                   message: Replicated SDK App status is not ready.
               - pass:
                   when: "true"
-                  message: Replicated SDK App status is not ready.
+                  message: Replicated SDK App status is ready.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Quotes the namespaces defined in the support bundle secret. This also helps get rid of the following warnings from the linter in the vendor portal:

![Screenshot 2024-05-14 at 2 48 06 PM jpg 2024-05-14 at 11 58 29 AM](https://github.com/replicatedhq/replicated-sdk/assets/39952863/5de7efcc-79f8-45b1-a787-15fdb4f876d5)

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Fixes an issue where the namespace fields in the support bundle spec were not quoted, which caused the linter to show schema warnings.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE