### PR TITLE
specify namespace in logs collector

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -500,7 +500,7 @@ jobs:
           integration-enabled: 'false'
           is-airgap: 'true'
 
-      - name: Validate support bundle instance report
+      - name: Validate support bundle contents
         run: |
           ./support-bundle --load-cluster-specs --interactive=false
           tar xzf support-bundle-*.tar.gz
@@ -510,6 +510,10 @@ jobs:
           fi
           if ! ls support-bundle-*/secrets/*/replicated-custom-app-metrics-report/report.json; then
             echo "Did not find replicated-custom-app-metrics-report in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated/logs/*/*.log; then
+            echo "Did not find replicated pod logs in support bundle"
             exit 1
           fi
           rm -rf support-bundle-*
@@ -553,7 +557,7 @@ jobs:
           deployed-via-kubectl: 'true'
           is-airgap: 'true'
 
-      - name: Validate support bundle instance report
+      - name: Validate support bundle contents
         run: |
           ./support-bundle --load-cluster-specs --interactive=false
           tar xzf support-bundle-*.tar.gz
@@ -563,6 +567,10 @@ jobs:
           fi
           if ! ls support-bundle-*/secrets/*/replicated-custom-app-metrics-report/report.json; then
             echo "Did not find replicated-custom-app-metrics-report in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated/logs/*/*.log; then
+            echo "Did not find replicated pod logs in support bundle"
             exit 1
           fi
           rm -rf support-bundle-*

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -24,6 +24,7 @@ stringData:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
               {{- end }}
+            namespace: {{ include "replicated.namespace" . | quote }}
             name: replicated/logs
         - http:
             collectorName: replicated-app-info


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This PR adds the deployed namespace in the logs collector that is part of the Replicated SDK support bundle. This fixes an issue where the logs may fail to collect in environments with namespace-restricted RBAC.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes an issue where the replicated pod logs collector could fail in environments with namespace-restricted RBAC
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->