### PR TITLE
Use exec collectors instead of http for support bundles

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -516,6 +516,22 @@ jobs:
             echo "Did not find replicated pod logs in support bundle"
             exit 1
           fi
+          if ! ls support-bundle-*/replicated-sdk/*/*/replicated-app-history-stdout.txt; then
+            echo "Did not find replicated-app-history-stdout.txt in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated-sdk/*/*/replicated-app-updates-stdout.txt; then
+            echo "Did not find replicated-app-updates-stdout.txt in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated-sdk/*/*/replicated-app-info-stdout.txt; then
+            echo "Did not find replicated-app-info-stdout.txt in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated-sdk/*/*/replicated-license-info-stdout.txt; then
+            echo "Did not find replicated-license-info-stdout.txt in support bundle"
+            exit 1
+          fi
           rm -rf support-bundle-*
 
       - name: Uninstall test-chart via Helm
@@ -571,6 +587,22 @@ jobs:
           fi
           if ! ls support-bundle-*/replicated/logs/*/*.log; then
             echo "Did not find replicated pod logs in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated-sdk/*/*/replicated-app-history-stdout.txt; then
+            echo "Did not find replicated-app-history-stdout.txt in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated-sdk/*/*/replicated-app-updates-stdout.txt; then
+            echo "Did not find replicated-app-updates-stdout.txt in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated-sdk/*/*/replicated-app-info-stdout.txt; then
+            echo "Did not find replicated-app-info-stdout.txt in support bundle"
+            exit 1
+          fi
+          if ! ls support-bundle-*/replicated-sdk/*/*/replicated-license-info-stdout.txt; then
+            echo "Did not find replicated-license-info-stdout.txt in support bundle"
             exit 1
           fi
           rm -rf support-bundle-*

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -18,6 +18,22 @@ stringData:
       name: {{ include "replicated.supportBundleName" . }}
     spec:
       collectors:
+        - exec:
+            name: replicated-app-info-exec 
+            selector:
+              {{- include "replicated.labels" . | nindent 4 }}
+            namespace: {{ include "replicated.namespace" . }}
+            command: ["curl"]
+            args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/info"]
+            timeout: 5s
+        - exec:
+            name: replicated-license-info-exec 
+            selector:
+              {{- include "replicated.labels" . | nindent 4 }}
+            namespace: {{ include "replicated.namespace" . }}
+            command: ["curl"]
+            args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/license/info"]
+            timeout: 5s
         - logs:
             collectorName: replicated-logs
             selector:

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -1,5 +1,5 @@
 {{/*
-Renders the Support Bundle secret to be used by replicated
+Renders the Support Bundle secret to be used by replicated 
 */}}
 ---
 apiVersion: v1

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -21,7 +21,9 @@ stringData:
         - exec:
             name: replicated-app-info-exec 
             selector:
-              {{- include "replicated.labels" . | nindent 4 }}
+              {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
+              - {{ $k }}={{ $v }}
+              {{- end }}
             namespace: {{ include "replicated.namespace" . }}
             command: ["curl"]
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/info"]
@@ -29,7 +31,9 @@ stringData:
         - exec:
             name: replicated-license-info-exec 
             selector:
-              {{- include "replicated.labels" . | nindent 4 }}
+              {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
+              - {{ $k }}={{ $v }}
+              {{- end }}
             namespace: {{ include "replicated.namespace" . }}
             command: ["curl"]
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/license/info"]

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -19,6 +19,29 @@ stringData:
     spec:
       collectors:
         - exec:
+            name: replicated-app-updates
+            collectorName: replicated-app-updates
+            selector:
+              {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
+              - {{ $k }}={{ $v }}
+              {{- end }}
+            namespace: {{ include "replicated.namespace" . }}
+            command: ["curl"]
+            args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/updates"]
+            timeout: 5s
+        - exec:
+            name: replicated-app-history
+            collectorName: replicated-app-history
+            selector:
+              {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
+              - {{ $k }}={{ $v }}
+              {{- end }}
+            namespace: {{ include "replicated.namespace" . }}
+            command: ["curl"]
+            args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/history"]
+            timeout: 5s
+        - exec:
+            name: replicated-app-info
             collectorName: replicated-app-info
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
@@ -29,6 +52,7 @@ stringData:
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/info"]
             timeout: 5s
         - exec:
+            name: replicated-license-info
             collectorName: replicated-license-info
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -19,7 +19,7 @@ stringData:
     spec:
       collectors:
         - exec:
-            name: replicated-app-updates
+            name: replicated-sdk
             collectorName: replicated-app-updates
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
@@ -30,7 +30,7 @@ stringData:
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/updates"]
             timeout: 5s
         - exec:
-            name: replicated-app-history
+            name: replicated-sdk
             collectorName: replicated-app-history
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
@@ -41,7 +41,7 @@ stringData:
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/history"]
             timeout: 5s
         - exec:
-            name: replicated-app-info
+            name: replicated-sdk
             collectorName: replicated-app-info
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
@@ -52,7 +52,7 @@ stringData:
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/info"]
             timeout: 5s
         - exec:
-            name: replicated-license-info
+            name: replicated-sdk
             collectorName: replicated-license-info
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}

--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -19,7 +19,7 @@ stringData:
     spec:
       collectors:
         - exec:
-            name: replicated-app-info-exec 
+            collectorName: replicated-app-info
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
@@ -29,7 +29,7 @@ stringData:
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/info"]
             timeout: 5s
         - exec:
-            name: replicated-license-info-exec 
+            collectorName: replicated-license-info
             selector:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
@@ -46,20 +46,6 @@ stringData:
               {{- end }}
             namespace: {{ include "replicated.namespace" . | quote }}
             name: replicated/logs
-        - http:
-            collectorName: replicated-app-info
-            get:
-              url: http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/info
-              headers:
-                User-Agent: "troubleshoot.sh/support-bundle"
-              timeout: 5s
-        - http:
-            collectorName: replicated-license-info
-            get:
-              url: http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/license/info
-              headers:
-                User-Agent: "troubleshoot.sh/support-bundle"
-              timeout: 5s
         - secret:
             namespace: {{ include "replicated.namespace" . | quote }}
             name: replicated-instance-report

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -31,11 +31,17 @@ import (
 )
 
 type GetCurrentAppInfoResponse struct {
+	InstanceID     string              `json:"instanceID"`
 	AppSlug        string              `json:"appSlug"`
 	AppName        string              `json:"appName"`
 	AppStatus      appstatetypes.State `json:"appStatus"`
 	HelmChartURL   string              `json:"helmChartURL,omitempty"`
 	CurrentRelease AppRelease          `json:"currentRelease"`
+
+	ChannelID       string `json:"channelID"`
+	ChannelName     string `json:"channelName"`
+	ChannelSequence int64  `json:"channelSequence"`
+	ReleaseSequence int64  `json:"releaseSequence"`
 }
 
 type GetAppHistoryResponse struct {
@@ -79,8 +85,13 @@ func GetCurrentAppInfo(w http.ResponseWriter, r *http.Request) {
 
 	if isIntegrationModeEnabled {
 		response := GetCurrentAppInfoResponse{
-			AppSlug: store.GetStore().GetAppSlug(),
-			AppName: store.GetStore().GetAppName(),
+			InstanceID:      store.GetStore().GetAppID(),
+			AppSlug:         store.GetStore().GetAppSlug(),
+			AppName:         store.GetStore().GetAppName(),
+			ChannelID:       store.GetStore().GetChannelID(),
+			ChannelName:     store.GetStore().GetChannelName(),
+			ChannelSequence: store.GetStore().GetChannelSequence(),
+			ReleaseSequence: store.GetStore().GetReleaseSequence(),
 		}
 
 		mockData, err := integration.GetMockData(r.Context(), clientset, store.GetStore().GetNamespace())
@@ -102,6 +113,7 @@ func GetCurrentAppInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := GetCurrentAppInfoResponse{
+		InstanceID:   store.GetStore().GetAppID(),
 		AppSlug:      store.GetStore().GetAppSlug(),
 		AppName:      store.GetStore().GetAppName(),
 		AppStatus:    store.GetStore().GetAppStatus().State,
@@ -111,6 +123,10 @@ func GetCurrentAppInfo(w http.ResponseWriter, r *http.Request) {
 			CreatedAt:    store.GetStore().GetReleaseCreatedAt(),
 			ReleaseNotes: store.GetStore().GetReleaseNotes(),
 		},
+		ChannelID:       store.GetStore().GetChannelID(),
+		ChannelName:     store.GetStore().GetChannelName(),
+		ChannelSequence: store.GetStore().GetChannelSequence(),
+		ReleaseSequence: store.GetStore().GetReleaseSequence(),
 	}
 
 	if helm.IsHelmManaged() {

--- a/pkg/handlers/app.go
+++ b/pkg/handlers/app.go
@@ -31,17 +31,16 @@ import (
 )
 
 type GetCurrentAppInfoResponse struct {
-	InstanceID     string              `json:"instanceID"`
-	AppSlug        string              `json:"appSlug"`
-	AppName        string              `json:"appName"`
-	AppStatus      appstatetypes.State `json:"appStatus"`
-	HelmChartURL   string              `json:"helmChartURL,omitempty"`
-	CurrentRelease AppRelease          `json:"currentRelease"`
-
-	ChannelID       string `json:"channelID"`
-	ChannelName     string `json:"channelName"`
-	ChannelSequence int64  `json:"channelSequence"`
-	ReleaseSequence int64  `json:"releaseSequence"`
+	InstanceID      string              `json:"instanceID"`
+	AppSlug         string              `json:"appSlug"`
+	AppName         string              `json:"appName"`
+	AppStatus       appstatetypes.State `json:"appStatus"`
+	HelmChartURL    string              `json:"helmChartURL,omitempty"`
+	CurrentRelease  AppRelease          `json:"currentRelease"`
+	ChannelID       string              `json:"channelID"`
+	ChannelName     string              `json:"channelName"`
+	ChannelSequence int64               `json:"channelSequence"`
+	ReleaseSequence int64               `json:"releaseSequence"`
 }
 
 type GetAppHistoryResponse struct {

--- a/pkg/handlers/license.go
+++ b/pkg/handlers/license.go
@@ -15,11 +15,23 @@ import (
 )
 
 type LicenseInfo struct {
-	LicenseID     string `json:"licenseID"`
-	ChannelName   string `json:"channelName"`
-	CustomerName  string `json:"customerName"`
-	CustomerEmail string `json:"customerEmail"`
-	LicenseType   string `json:"licenseType"`
+	LicenseID                      string                                  `json:"licenseID"`
+	AppSlug                        string                                  `json:"appSlug"`
+	ChannelName                    string                                  `json:"channelName"`
+	CustomerName                   string                                  `json:"customerName"`
+	CustomerEmail                  string                                  `json:"customerEmail"`
+	LicenseType                    string                                  `json:"licenseType"`
+	ChannelID                      string                                  `json:"channelID"`
+	LicenseSequence                int64                                   `json:"licenseSequence"`
+	IsAirgapSupported              bool                                    `json:"isAirgapSupported"`
+	IsGitOpsSupported              bool                                    `json:"isGitOpsSupported"`
+	IsIdentityServiceSupported     bool                                    `json:"isIdentityServiceSupported"`
+	IsGeoaxisSupported             bool                                    `json:"isGeoaxisSupported"`
+	IsSnapshotSupported            bool                                    `json:"isSnapshotSupported"`
+	IsSupportBundleUploadSupported bool                                    `json:"isSupportBundleUploadSupported"`
+	IsSemverRequired               bool                                    `json:"isSemverRequired"`
+	Endpoint                       string                                  `json:"endpoint"`
+	Entitlements                   map[string]kotsv1beta1.EntitlementField `json:"entitlements"`
 }
 
 func GetLicenseInfo(w http.ResponseWriter, r *http.Request) {
@@ -97,10 +109,22 @@ func GetLicenseField(w http.ResponseWriter, r *http.Request) {
 
 func licenseInfoFromLicense(license *kotsv1beta1.License) LicenseInfo {
 	return LicenseInfo{
-		LicenseID:     license.Spec.LicenseID,
-		ChannelName:   license.Spec.ChannelName,
-		CustomerName:  license.Spec.CustomerName,
-		CustomerEmail: license.Spec.CustomerEmail,
-		LicenseType:   license.Spec.LicenseType,
+		LicenseID:                      license.Spec.LicenseID,
+		AppSlug:                        license.Spec.AppSlug,
+		ChannelName:                    license.Spec.ChannelName,
+		CustomerName:                   license.Spec.CustomerName,
+		CustomerEmail:                  license.Spec.CustomerEmail,
+		LicenseType:                    license.Spec.LicenseType,
+		ChannelID:                      license.Spec.ChannelID,
+		LicenseSequence:                license.Spec.LicenseSequence,
+		IsAirgapSupported:              license.Spec.IsAirgapSupported,
+		IsGitOpsSupported:              license.Spec.IsGitOpsSupported,
+		IsIdentityServiceSupported:     license.Spec.IsIdentityServiceSupported,
+		IsGeoaxisSupported:             license.Spec.IsGeoaxisSupported,
+		IsSnapshotSupported:            license.Spec.IsSnapshotSupported,
+		IsSupportBundleUploadSupported: license.Spec.IsSupportBundleUploadSupported,
+		IsSemverRequired:               license.Spec.IsSemverRequired,
+		Endpoint:                       license.Spec.Endpoint,
+		Entitlements:                   license.Spec.Entitlements,
 	}
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

- Remove `http` collectors (they were not working)
- Uses exec collectors via `curl`
- Updates `/license/info` and `/app/info` SDK endpoints to return additional details

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Returns additional license-info and app-info details on respective SDK HTTP endpoints.  
- Support bundle spec updated to extract license, app, history, and release information via an exec collector.  
```
Notice the new `replicated-app*` exec folders
<img width="763" alt="Screenshot 2024-06-11 at 3 48 56 PM" src="https://github.com/replicatedhq/replicated-sdk/assets/8316724/8051a1e2-891d-4f0b-8a8c-9a5b3b744be9">

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->