### PR TITLE
Allow specifying custom Certificate Authority as a ConfigMap name

### DIFF
--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -48,6 +48,12 @@ spec:
       - name: replicated
         secret:
           secretName: {{ include "replicated.secretName" . }}
+      {{- if .Values.privateCAConfigmap }}
+      - name: additional-certs
+        configMap:
+          defaultMode: 420
+          name: {{ .Values.privateCAConfigmap }}
+      {{- end }}
       containers:
       - name: replicated
         image: {{ index .Values.images "replicated-sdk" }}
@@ -60,9 +66,17 @@ spec:
           mountPath: /etc/replicated/config.yaml
           readOnly: true
           subPath: config.yaml
+        {{- if .Values.privateCAConfigmap }}
+        - mountPath: /certs
+          name: additional-certs
+        {{- end }}
         env:
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.privateCAConfigmap }}
+        - name: SSL_CERT_DIR
+          value: /certs
         {{- end }}
         - name: REPLICATED_NAMESPACE
           valueFrom:

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -45,6 +45,8 @@ service:
   type: ClusterIP
   port: 3000
 
+privateCAConfigmap: ~
+
 extraEnv: []
 
 # "integration" mode related values.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This adds support for specifying additional Certificate Authorities that can be used for adding private CAs when deploying behind a proxy.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/98357/use-a-custom-certificate-authority-with-replicated-sdk

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

Relevant docs PR: https://github.com/replicatedhq/replicated-docs/pull/2667

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for custom Certificate Authorities.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->