### PR TITLE
Use listReleases instead of listTags

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,13 +30,13 @@ jobs:
           script: |
             const {
               data: [latest, previous],
-            } = await github.rest.repos.listTags({
+            } = await github.rest.repos.listReleases({
               ...context.repo,
               per_page: 2,
               page: 1,
             });
-            core.setOutput("tag", latest.name.replace(/^v/, ''));
-            core.setOutput("previous-tag", previous.name.replace(/^v/, ''));
+            core.setOutput("tag", latest.tag_name.replace(/^v/, ''));
+            core.setOutput("previous-tag", previous.tag_name.replace(/^v/, ''));
 
   generate-release-notes-pr:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Use listReleases instead of listTags when looking for latest release because tags are sorted alphabetically and releases are sorted chronologically.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/109223/do-not-put-a-v-prefix-on-sdk-versions-in-github

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->