### PR TITLE
Ability to specify additional CA using a secret name/key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ vet:
 
 .PHONY: build-ttl.sh
 build-ttl.sh:
-	docker buildx build . -t ttl.sh/${USER}/replicated-sdk:24h -f deploy/Dockerfile
+	docker buildx build . -t ttl.sh/${USER}/replicated-sdk:24h -f deploy/Dockerfile --load
 	docker push ttl.sh/${USER}/replicated-sdk:24h
 
 	make -C chart build-ttl.sh

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -53,6 +53,14 @@ spec:
         configMap:
           defaultMode: 420
           name: {{ .Values.privateCAConfigmap }}
+      {{- else if .Values.privateCASecret }}
+      - name: additional-certs
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.privateCASecret.name }}
+          items:
+          - key: {{ .Values.privateCASecret.key }}
+            path: ca.crt
       {{- end }}
       containers:
       - name: replicated
@@ -74,12 +82,16 @@ spec:
         {{- if .Values.privateCAConfigmap }}
         - mountPath: /certs
           name: additional-certs
+        {{- else if .Values.privateCASecret }}
+        - mountPath: /certs/ca.crt
+          subPath: ca.crt
+          name: additional-certs
         {{- end }}
         env:
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.privateCAConfigmap }}
+        {{- if or .Values.privateCAConfigmap .Values.privateCASecret }}
         - name: SSL_CERT_DIR
           value: /certs
         {{- end }}

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -60,6 +60,7 @@ service:
   port: 3000
 
 privateCAConfigmap: ~
+privateCASecret: ~
 
 extraEnv: []
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

In addition to using a configmap to provide SDK with custom CA, this allows using a secret.  Example values:

```
privateCASecret:
  name: additional-ca
  key: custom-ca.crt
```

This is a follow up to https://github.com/replicatedhq/replicated-sdk/pull/209

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/113584/can-t-reuse-existing-secret-for-custom-ca

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for specifying custom Certificate Authorities using a secret.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->

https://github.com/replicatedhq/replicated-docs/pull/2742