### PR TITLE
Allow specifying ClusterRole when deploying Replicated SDK

### DIFF
--- a/chart/templates/replicated-clusterrolebinding.yaml
+++ b/chart/templates/replicated-clusterrolebinding.yaml
@@ -1,6 +1,6 @@
-{{ if and (not .Values.serviceAccountName) (not .Values.clusterRole) }}
+{{ if and .Values.clusterRole (not .Values.serviceAccountName) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "replicated.labels" . | nindent 4 }}
@@ -8,8 +8,8 @@ metadata:
   namespace: {{ include "replicated.namespace" . | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "replicated.roleName" . }}
+  kind: ClusterRole
+  name: {{ .Values.clusterRole }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "replicated.serviceAccountName" . }}

--- a/chart/templates/replicated-role.yaml
+++ b/chart/templates/replicated-role.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.serviceAccountName }}
+{{ if and (not .Values.serviceAccountName) (not .Values.clusterRole) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -34,6 +34,7 @@ statusInformers: null
 replicatedAppEndpoint: ""
 
 serviceAccountName: ""
+clusterRole: ""
 imagePullSecrets: []
 nameOverride: ""
 namespaceOverride: ""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Allows specifying ClusterRole name to use for the service account that will be created for Replicated SDK.

Relevant KOTS PR: https://github.com/replicatedhq/kots/pull/4952

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/114128/replicated-sdk-reports-k0s-when-installed-in-embedded-cluster-causing-distribution-to-flip-flop-in-events-view

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
* Adds support for specifying ClusterRole for Replicated SDK RBAC.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->