### PR TITLE
Handle bad metadata secret values gracefully

### DIFF
--- a/deploy/apko.yaml.tmpl
+++ b/deploy/apko.yaml.tmpl
@@ -6,7 +6,7 @@ contents:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     - ./melange.rsa.pub
   packages:
-    - replicated-head  # This is expected to be built locally by `melange`.
+    - replicated  # This is expected to be built locally by `melange`.
     - bash
     - busybox
     - curl

--- a/deploy/melange.yaml.tmpl
+++ b/deploy/melange.yaml.tmpl
@@ -1,5 +1,5 @@
 package:
-  name: replicated-head
+  name: replicated
   version: ${GIT_TAG}
   epoch: 0
   description: replicated package

--- a/pkg/meta/latest_custom_metrics.go
+++ b/pkg/meta/latest_custom_metrics.go
@@ -16,7 +16,7 @@ func SyncCustomAppMetrics(ctx context.Context, clientset kubernetes.Interface, n
 	existing := map[string]interface{}{}
 
 	err := get(ctx, clientset, namespace, customMetricsSecretKey, &existing)
-	if err != nil && errors.Cause(err) != ErrReplicatedMetadataSecretNotFound {
+	if err != nil && errors.Cause(err) != ErrReplicatedMetadataNotFound {
 		return nil, errors.Wrapf(err, "failed to get custom metrics data")
 	}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

If metadata secret becomes malformed, reporting custom metrics will start failing and will not recover on its own. When the secret or the data are malformed, the API should continue to function.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/117030/replicated-sdk-fails-to-report-custom-metrics-if-the-latest-custom-metrics-key-is-not-there

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes a bug that could cause custom metrics to not be reported.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE