### PR TITLE
Allow setting affinity for replicated deployment

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -162,6 +162,26 @@ jobs:
           fi
 
 
+          cat << EOF > test-values.yaml 
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: production/node-pool
+                    operator: In
+                    values:
+                    - replicated-sdk
+          EOF
+
+          output=$(helm template oci://ttl.sh/automated-${{ github.run_id }}/replicated --version 0.0.0 --values test-values.yaml)
+
+          if ! echo $output | grep -q 'affinity:'; then
+            printf "user-set affinity should exist:\n\n%s\n\n" "$output"
+            exit 1
+          fi
+
+
           cat << EOF > test-values.yaml
           statusInformers: []
           EOF

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -41,6 +41,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if $podSecurityContext.enabled }}
       securityContext: {{- omit $podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -77,3 +77,5 @@ replicatedID: ""
 appID: ""
 
 tolerations: []
+
+affinity: ~


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Allow setting `affinity` on replicated deployment, similar to `tolerations`

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/102275/replicated-sdk-chart-should-support-configuring-node-affinity-rules

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Adds support for setting `affinity` for Replicated SDK deployment
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
https://github.com/replicatedhq/replicated-docs/pull/2906