### PR TITLE
Mock all release data without mixing with real data

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -7,6 +7,10 @@ import (
 	"github.com/replicatedhq/replicated-sdk/pkg/logger"
 )
 
+const (
+	MockDataHeader = "X-Replicated-Mock-Data"
+)
+
 func JSON(w http.ResponseWriter, code int, payload interface{}) {
 	response, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/integration/data/default_mock_data.yaml
+++ b/pkg/integration/data/default_mock_data.yaml
@@ -8,30 +8,34 @@ appStatus:
   state: ready
 helmChartURL: oci://registry.replicated.com/dev-app/dev-channel/dev-parent-chart
 currentRelease:
-  versionLabel: 0.1.3
-  releaseNotes: "release notes 0.1.3"
+  versionLabel: 0.1.3-mock-release
+  releaseNotes: "mock release notes for 0.1.3"
   createdAt: 2023-05-23T20:58:07Z
   deployedAt: 2023-05-23T21:58:07Z
   helmReleaseName: dev-parent-chart
   helmReleaseRevision: 3
   helmReleaseNamespace: default
+  channelID: dev-channel
+  channelName: Dev Channel
+  channelSequence: 13
+  releaseSequence: 113
 deployedReleases:
 - versionLabel: 0.1.1
-  releaseNotes: "release notes 0.1.1"
+  releaseNotes: "mock release release notes for 0.1.1"
   createdAt: 2023-05-21T20:58:07Z
   deployedAt: 2023-05-21T21:58:07Z
   helmReleaseName: dev-parent-chart
   helmReleaseRevision: 1
   helmReleaseNamespace: default
 - versionLabel: 0.1.2
-  releaseNotes: "release notes 0.1.2"
+  releaseNotes: "mock release release notes for 0.1.2"
   createdAt: 2023-05-22T20:58:07Z
   deployedAt: 2023-05-22T21:58:07Z
   helmReleaseName: dev-parent-chart
   helmReleaseRevision: 2
   helmReleaseNamespace: default
 - versionLabel: 0.1.3
-  releaseNotes: "release notes 0.1.3"
+  releaseNotes: "mock release release notes for 0.1.3"
   createdAt: 2023-05-23T20:58:07Z
   deployedAt: 2023-05-23T21:58:07Z
   helmReleaseName: dev-parent-chart
@@ -39,10 +43,10 @@ deployedReleases:
   helmReleaseNamespace: default
 availableReleases:
 - versionLabel: 0.1.4
-  releaseNotes: "release notes 0.1.4"
+  releaseNotes: "mock release release notes for 0.1.4"
   createdAt: 2023-05-24T20:58:07Z
   deployedAt: 2023-05-24T21:58:07Z
 - versionLabel: 0.1.5
-  releaseNotes: "release notes 0.1.5"
+  releaseNotes: "mock release release notes for 0.1.5"
   createdAt: 2023-06-01T20:58:07Z
   deployedAt: 2023-06-01T21:58:07Z

--- a/pkg/integration/data/test_mock_data_v2.yaml
+++ b/pkg/integration/data/test_mock_data_v2.yaml
@@ -15,6 +15,10 @@ currentRelease:
   helmReleaseName: custom-helm-release-name
   helmReleaseRevision: 4
   helmReleaseNamespace: default
+  channelID: dev-channel
+  channelName: Dev Channel
+  channelSequence: 13
+  releaseSequence: 113
 deployedReleases:
 - versionLabel: custom-version-label-1
   releaseNotes: "custom release notes 1"

--- a/pkg/integration/mock_test.go
+++ b/pkg/integration/mock_test.go
@@ -193,8 +193,6 @@ func TestMock_SetMockData(t *testing.T) {
 					t.Errorf("SetMockData() \n\n%q", fmtJSONDiff(gotV2, testMockDataV2))
 				}
 			},
-			// want:    testMockDataV2,
-			// wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/integration/types/types.go
+++ b/pkg/integration/types/types.go
@@ -42,4 +42,8 @@ type MockRelease struct {
 	HelmReleaseName      string `json:"helmReleaseName" yaml:"helmReleaseName"`
 	HelmReleaseRevision  int    `json:"helmReleaseRevision" yaml:"helmReleaseRevision"`
 	HelmReleaseNamespace string `json:"helmReleaseNamespace" yaml:"helmReleaseNamespace"`
+	ChannelID            string `json:"channelID" yaml:"channelID"`
+	ChannelName          string `json:"channelName" yaml:"channelName"`
+	ChannelSequence      int64  `json:"channelSequence" yaml:"channelSequence"`
+	ReleaseSequence      int64  `json:"releaseSequence" yaml:"releaseSequence"`
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Add better indicators for mock data:
- Remove real channel/release info from `/app/info` endpoint and replace it with mock data for consistency
- Add `X-Replicated-Mock-Data: true` header to responses when mock data is used.
- Add "mock" to text fields to indicate that data is not real.

<img width="952" alt="Screenshot 2024-12-23 at 12 00 29 PM" src="https://github.com/user-attachments/assets/b4217ae0-6daf-4ff1-ad62-47296849cad2" />

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://app.shortcut.com/replicated/story/100946/integration-mode-is-messy-for-the-sdk-developer-experience-improve-sdk-integration-experience-as-part-of-calling-it-ga

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
- Adds support for mocking channelID, channelName, channelSequence, releaseSequence in current release info returned by /app/info API.
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->