### PR TITLE
feat: add ability to pass custom labels

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -33,7 +33,16 @@ helm.sh/chart: {{ include "replicated.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.labels }}
+{{- with .Values.commonLabels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{/* 
+Pod Labels
+*/}}
+{{- define "replicated.podLabels" -}}
+{{- with .Values.podLabels }}
 {{- toYaml . | nindent 0 }}
 {{- end }}
 {{- end }}
@@ -128,15 +137,3 @@ Resource Names
 {{- define "replicated.supportBundleName" -}}
   {{ include "replicated.name" . }}-supportbundle
 {{- end -}}
-
-{{/*
-Merge multiple maps
-Usage: include "replicated.mergeValues" (list $map1 $map2 $map3)
-*/}}
-{{- define "replicated.mergeValues" -}}
-{{- $result := dict }}
-{{- range . }}
-{{- $result = merge $result . }}
-{{- end }}
-{{- toYaml $result }}
-{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -131,7 +131,7 @@ Resource Names
 
 {{/*
 Merge multiple maps
-Usage: include "replicated.merge" (list $map1 $map2 $map3)
+Usage: include "replicated.mergeValues" (list $map1 $map2 $map3)
 */}}
 {{- define "replicated.mergeValues" -}}
 {{- $result := dict }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -33,6 +33,9 @@ helm.sh/chart: {{ include "replicated.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -125,3 +128,15 @@ Resource Names
 {{- define "replicated.supportBundleName" -}}
   {{ include "replicated.name" . }}-supportbundle
 {{- end -}}
+
+{{/*
+Merge multiple maps
+Usage: include "replicated.merge" (list $map1 $map2 $map3)
+*/}}
+{{- define "replicated.mergeValues" -}}
+{{- $result := dict }}
+{{- range . }}
+{{- $result = merge $result . }}
+{{- end }}
+{{- toYaml $result }}
+{{- end }}

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         checksum/replicated-secret: {{ include (print $.Template.BasePath "/replicated-secret.yaml") . | sha256sum }}
       labels:
-        {{- include "replicated.labels" . | nindent 8 }}
+        {{- include "replicated.mergeValues" (list (include "replicated.labels" . | fromYaml) .Values.podLabels) | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -31,7 +31,8 @@ spec:
       annotations:
         checksum/replicated-secret: {{ include (print $.Template.BasePath "/replicated-secret.yaml") . | sha256sum }}
       labels:
-        {{- include "replicated.mergeValues" (list (include "replicated.labels" . | fromYaml) .Values.podLabels) | nindent 8 }}
+        {{- include "replicated.labels" . | nindent 8 }}
+        {{- include "replicated.podLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -5,6 +5,11 @@
 global:
   imageRegistry: ""
 
+# Additional labels to add to all resources created by this chart
+labels: {}
+  # app.kubernetes.io/part-of: my-app
+  # environment: production
+
 # Deprecated: Use .Values.image instead of .Values.images
 # The following properties for the Replicated SDK image are deprecated:
 # 
@@ -46,6 +51,11 @@ containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
+
+# Additional labels to add only to the pod template
+podLabels: {}
+  # example.com/custom-label: value
+  # monitoring: enabled
 
 podSecurityContext:
   enabled: true

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -6,7 +6,7 @@ global:
   imageRegistry: ""
 
 # Additional labels to add to all resources created by this chart
-labels: {}
+commonLabels: {}
   # app.kubernetes.io/part-of: my-app
   # environment: production
 
@@ -52,10 +52,9 @@ containerSecurityContext:
   capabilities:
     drop: ["ALL"]
 
-# Additional labels to add only to the pod template
+# Additional labels to add to the pod template
 podLabels: {}
   # example.com/custom-label: value
-  # monitoring: enabled
 
 podSecurityContext:
   enabled: true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:
This PR adds support for custom labels in the Helm chart. It introduces two new values:
- `commonLabels`: Allows adding custom labels to all resources created by the chart
- `podLabels`: Allows adding pod-specific labels only to the pod template

Additionally, it introduces a generic helper function `replicated.mergeValues` that can be used to merge multiple maps, making the chart more maintainable and providing a reusable function for future needs.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
The PR introduces a new generic merge helper that could be useful for other parts of the chart in the future. We're currently using it to merge common labels with pod-specific labels in the deployment template.

#### Steps to reproduce
To test the new label functionality:

1. Install the chart with custom labels:
```yaml
commonLabels:
  environment: production
  team: platform
podLabels:
  monitoring: enabled
  custom.company.io/pod-label: value
```

2. Verify that:
   - All resources have the labels defined in `labels`
   - Only pods have both the common labels and the pod-specific labels from `podLabels`

#### Does this PR introduce a user-facing change?
```release-note
Add support for custom labels via labels and podLabels values
```

#### Does this PR require documentation?
