### PR TITLE
Use ttl.sh for daily scans

### DIFF
--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -36,13 +36,13 @@ jobs:
         uses: ./.github/actions/build-push-action
         with:
           context: deploy
-          image-name: replicated/replicated-sdk:${{ github.sha }}
+          image-name: ttl.sh/replicated/replicated-sdk:${{ github.sha }}
           git-tag: "1.0.0" # can't use ${{ github.sha }} because melange config requires strict format.
           
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'replicated/replicated-sdk:${{ github.sha }}'
+          image-ref: 'ttl.sh/replicated/replicated-sdk:${{ github.sha }}'
           format: 'sarif'          
           output: 'trivy-results.sarif'
           ignore-unfixed: true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

Since the [switch to chainguard](https://github.com/replicatedhq/replicated-sdk/commit/16b22c2ab0621597fbdbbdf9ef8fc835e294fb8e#diff-2668ebb199a46c01733d0e145f741a3183dc211c98fe515e1952bf6e19522096L37), daily_scan job has been failing with

> Error: publishing images from index: POST https://index.docker.io/v2/replicated/replicated-sdk/blobs/uploads/: UNAUTHORIZED: authentication required; 

This will use ttl.sh, similar to [e2e tests](https://github.com/replicatedhq/replicated-sdk/blob/45d91c230abb34a6be1465556821980216056fd1/.github/workflows/main.yaml#L59).

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->