### PR TITLE
Scan the most recent release for CVEs

### DIFF
--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -60,7 +60,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'release-cve-scan'

--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -5,9 +5,14 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions: {}  # Remove all permissions by default
+
 jobs:
   scan_filesystem:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read        # For checkout
+      security-events: write # For uploading SARIF results
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,30 +30,42 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+    timeout-minutes: 30
 
-  scan_image:
-    runs-on: ubuntu-22.04
+  scan-release:
+    name: Scan Current Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read        # For reading releases
+      security-events: write # For uploading SARIF results
+      
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build replicated image
-        uses: ./.github/actions/build-push-action
+      - name: Get latest release
+        id: get_release
+        uses: actions/github-script@v6
         with:
-          context: deploy
-          image-name: ttl.sh/replicated/replicated-sdk:${{ github.sha }}
-          git-tag: "1.0.0" # can't use ${{ github.sha }} because melange config requires strict format.
-          
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            core.setOutput('tag_name', release.data.tag_name);
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'ttl.sh/replicated/replicated-sdk:${{ github.sha }}'
-          format: 'sarif'          
+          image-ref: 'index.docker.io/replicated/replicated-sdk:${{ steps.get_release.outputs.tag_name }}'
+          format: 'sarif'
           output: 'trivy-results.sarif'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH,MEDIUM'
+          severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+          category: 'release-cve-scan'
+    timeout-minutes: 30
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:
Modifies the security scanning strategy to scan the actual published image from DockerHub instead of rebuilding and scanning a fresh image.

Previously, the scan would rebuild the image using the latest dependencies from Chainguard/apko, which meant we were scanning a potential future release rather than our current production release. This defeated the purpose of detecting new vulnerabilities in our published image.

The new workflow:
- Gets the latest release tag
- Scans that specific published image directly from DockerHub
- Reports findings to GitHub Security tab
- This change ensures we detect new CVEs that affect our users' currently deployed version, rather than scanning a fresh build with updated dependencies.




#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

- The workflow runs daily at midnight UTC
- Uses minimal permissions following security best practices
- Includes timeouts to prevent hung jobs
- Uses concurrency limits to prevent multiple scans running simultaneously
- Results can be viewed in GitHub Security tab under "Code scanning"

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->
1. Merge PR
2. Go to Actions tab
3. Run the "Scan vulnerabilities" workflow manually using workflow_dispatch
4. Check Security tab > Code scanning for results
5. Results should appear under both default and 'release-cve-scan' categories

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->
NONE