### PR TITLE
Add category field for sarif report in daily scan

### DIFF
--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+          category: 'filesystem-scan'  # Added explicit category for filesystem scan
     timeout-minutes: 30
 
   scan-release:
@@ -63,7 +64,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
-          category: 'release-cve-scan'
+          category: 'image-scan-replicated-sdk-${{ steps.get_release.outputs.tag_name }}'  # Changed to include image name and tag
     timeout-minutes: 30
 
 concurrency:


### PR DESCRIPTION


<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:


Update daily-scan.yaml to add the category field for the sarif report. We need this because we need a way to make sure we can differentiate the trivy filesystem and image scans separate from dependabot. It also should let me associate the results with a specific image/release within reporting systems.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->