### PR TITLE
feat: add nodeSelector value to helm chart

### DIFF
--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -38,6 +38,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/chart/values.yaml.tmpl
+++ b/chart/values.yaml.tmpl
@@ -91,6 +91,8 @@ isAirgap: false
 replicatedID: ""
 appID: ""
 
+nodeSelector: ~
+
 tolerations: []
 
 affinity: ~


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What this PR does / why we need it:

This adds .Values.nodeSelector to the helm chart. This makes it easier to enforce scheduling onto specific nodes when the full expressiveness of affinity is not needed.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
No current issue, but related to #164 

#### Special notes for your reviewer:
<!--
Any additional special notes for your reviewer.
-->

#### Steps to reproduce
<!---
Please provide minimum instructions for how someone can view/test/verify your changes.
-->

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

#### Does this PR require documentation?
<!--
If no, just write "NONE" below.
If yes, link to the related https://github.com/replicatedhq/replicated-docs documentation PR:
-->

NONE