### PR TITLE
Fix cross compile in action runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,14 +28,18 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const {
-              data: [previous],
-            } = await github.rest.repos.listReleases({
-              ...context.repo,
-              per_page: 1,
-              page: 1,
-            });
-            core.setOutput("previous-tag", previous.tag_name.replace(/^v/, ''));
+            try {
+              const {
+                data: [previous],
+              } = await github.rest.repos.listReleases({
+                ...context.repo,
+                per_page: 1,
+                page: 1,
+              });
+              core.setOutput("previous-tag", previous.tag_name.replace(/^v/, ''));
+            } catch (error) {
+              core.setFailed("Failed to get previous release tag: " + error.message);
+            }
 
   generate-release-notes-pr:
     runs-on: ubuntu-22.04
@@ -55,14 +59,19 @@ jobs:
           -d "{\"event_type\": \"replicated-sdk-release-notes\", \"client_payload\": {\"version\": \"${GIT_TAG}\", \"prev_version\": \"${GIT_PREV_TAG}\" }}" \
           "https://api.github.com/repos/replicatedhq/replicated-docs/dispatches"
 
-  build-and-push-image:
-    runs-on: 'ubuntu-22.04'
-    needs:
-      - get-tags
+  staging:
+    runs-on:
+      labels: ReplicatedSDK
     outputs:
       digest: ${{ steps.dagger-publish.outputs.stdout }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
+
       - uses: dagger/dagger-for-github@8.0.0
         id: dagger-publish
         env:
@@ -70,5 +79,28 @@ jobs:
           OP_SERVICE_ACCOUNT_PRODUCTION: ${{ secrets.OP_SERVICE_ACCOUNT_PRODUCTION }}
         with:
           verb: call
-          args: publish --progress=plain --op-service-account=env:OP_SERVICE_ACCOUNT --op-service-account-production=env:OP_SERVICE_ACCOUNT_PRODUCTION --dev=false --staging=true --production=true --version ${{ github.ref_name }}
+          args: publish --progress=plain --op-service-account=env:OP_SERVICE_ACCOUNT --op-service-account-production=env:OP_SERVICE_ACCOUNT_PRODUCTION --dev=false --staging=true --production=false --version ${{ github.ref_name }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+  production:
+    runs-on:
+      labels: ReplicatedSDK
+    outputs:
+      digest: ${{ steps.dagger-publish.outputs.stdout }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
+
+      - uses: dagger/dagger-for-github@8.0.0
+        id: dagger-publish
+        env:
+          OP_SERVICE_ACCOUNT: ${{ secrets.OP_SERVICE_ACCOUNT }}
+          OP_SERVICE_ACCOUNT_PRODUCTION: ${{ secrets.OP_SERVICE_ACCOUNT_PRODUCTION }}
+        with:
+          verb: call
+          args: publish --progress=plain --op-service-account=env:OP_SERVICE_ACCOUNT --op-service-account-production=env:OP_SERVICE_ACCOUNT_PRODUCTION --dev=false --staging=false --production=true --version ${{ github.ref_name }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/dagger/chainguard.go
+++ b/dagger/chainguard.go
@@ -79,15 +79,20 @@ func publishChainguardImage(
 	// get the registry address from the image path
 	registry := strings.Split(imagePath, "/")[0]
 
+	// Create a fresh Apko instance and explicitly set auth
 	apko := dag.Apko()
 
+	var apkoWithAuth *dagger.Apko
+	// Now set the actual auth
 	if username != "" && password != nil {
-		apko = apko.WithRegistryAuth(username, password, dagger.ApkoWithRegistryAuthOpts{
+		apkoWithAuth = apko.WithRegistryAuth(username, password, dagger.ApkoWithRegistryAuthOpts{
 			Address: registry,
 		})
+	} else {
+		apkoWithAuth = apko
 	}
 
-	image := apko.
+	image := apkoWithAuth.
 		Publish(
 			updatedSource.WithDirectory("packages", amdPackages).
 				WithDirectory("packages", armPackages).


### PR DESCRIPTION
This adds QEMU to the runner so that it can cross compile (surprise requirement)
This uses a larger runner so it's quicker.

Then, the dagger-for-github caches creds. I've tried everything i can think of to reset these. It's passing the right creds, but publishing to staging and then prod in a single job always results in the 2nd publish 401.  Thie APKO step or dagger is caching that credential. 

To make this more reliable, split staging and prod into two steps. This does create 2 separate melange builds, but ultimately since they run in parallel, it actually results in a faster pipeline.