### PR TITLE
Fix slsa workflow execution

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -5,6 +5,11 @@ on:
       digest:
         description: "Digest to publish"
         required: true
+      production:
+        description: "Publish production (false for staging)"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   provenance-staging:
@@ -12,7 +17,7 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    if: success() && needs.package-and-publish-staging.result == 'success'
+    if: ${{ inputs.production == false }}
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
     with:
       image: registry.staging.replicated.com/library/replicated-sdk-image:${{ github.ref_name }}
@@ -26,7 +31,7 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    if: success() && needs.package-and-publish-production.result == 'success'
+    if: ${{ inputs.production == true }}
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
     with:
       image: registry.replicated.com/library/replicated-sdk-image:${{ github.ref_name }}

--- a/dagger/publish.go
+++ b/dagger/publish.go
@@ -98,7 +98,8 @@ func (m *ReplicatedSdk) Publish(
 		ctr := dag.Gh().
 			Run(fmt.Sprintf(`api /repos/replicatedhq/replicated-sdk/actions/workflows/slsa.yml/dispatches \
 				-f ref=main \
-				-f inputs[digest]=%s`, digest),
+				-f inputs[digest]=%s \
+				-f inputs[production]=%t`, digest, production),
 				dagger.GhRunOpts{
 					Token: githubToken,
 				},


### PR DESCRIPTION
#### What does this PR do?

The slsa workflow was being triggered by dagger on a tag being cut, however, it would exit immediately and perform  no work because it was expecting to have been executed as part of a larger actions workflow. It was looking for a `needs.package-and-publish-production.result` from a previous step run. 

I updated dagger to supply a bool to signal whether this is a staging/production run as a replacement.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

