### PR TITLE
Use actual image digest - as digest

### DIFF
--- a/dagger/chainguard.go
+++ b/dagger/chainguard.go
@@ -106,12 +106,12 @@ func publishChainguardImage(
 		)
 
 	// return the image digest
-	digest, err := image.ID(ctx)
+	digest, err := image.Digest(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	return string(digest), nil
+	return digest, nil
 }
 
 func sanitizeVersionForMelange(version string) string {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?

Uses the apko image digest, rather than id - as the actual digest. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

