### PR TITLE
Fix 'validate' CI run

### DIFF
--- a/dagger/e2e.go
+++ b/dagger/e2e.go
@@ -22,7 +22,7 @@ func e2e(
 
 	ctr := dag.Container().From("replicated/vendor-cli:latest").
 		WithSecretVariable("REPLICATED_API_TOKEN", replicatedServiceAccount).
-		WithExec([]string{"/replicated", "cluster", "create", "--distribution", distribution, "--version", version, "--wait", "5m", "--output", "json"})
+		WithExec([]string{"/replicated", "cluster", "create", "--distribution", distribution, "--version", version, "--wait", "15m", "--output", "json"})
 
 	out, err := ctr.Stdout(ctx)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?

This increases the timeout for the 'validate' CI run's creation of k8s clusters, allowing it to complete succesfully.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

