### PR TITLE
use cachebust exec for 'kubectl get' commands

### DIFF
--- a/dagger/e2e.go
+++ b/dagger/e2e.go
@@ -85,10 +85,10 @@ func e2e(
 	ctr = dag.Container().From("bitnami/kubectl:latest").
 		WithFile("/root/.kube/config", kubeconfigSource.File("/kubeconfig")).
 		WithEnvVariable("KUBECONFIG", "/root/.kube/config").
-		WithExec(
+		With(CacheBustingExec(
 			[]string{
 				"kubectl", "get", "ns",
-			})
+			}))
 
 	out, err = ctr.Stdout(ctx)
 	if err != nil {
@@ -100,10 +100,10 @@ func e2e(
 	ctr = dag.Container().From("bitnami/kubectl:latest").
 		WithFile("/root/.kube/config", kubeconfigSource.File("/kubeconfig")).
 		WithEnvVariable("KUBECONFIG", "/root/.kube/config").
-		WithExec(
+		With(CacheBustingExec(
 			[]string{
 				"kubectl", "get", "pods",
-			})
+			}))
 
 	out, err = ctr.Stdout(ctx)
 	if err != nil {
@@ -152,10 +152,10 @@ func e2e(
 	ctr = dag.Container().From("bitnami/kubectl:latest").
 		WithFile("/root/.kube/config", kubeconfigSource.File("/kubeconfig")).
 		WithEnvVariable("KUBECONFIG", "/root/.kube/config").
-		WithExec(
+		With(CacheBustingExec(
 			[]string{
 				"kubectl", "get", "secrets",
-			})
+			}))
 
 	out, err = ctr.Stdout(ctx)
 	if err != nil {
@@ -167,10 +167,10 @@ func e2e(
 	ctr = dag.Container().From("bitnami/kubectl:latest").
 		WithFile("/root/.kube/config", kubeconfigSource.File("/kubeconfig")).
 		WithEnvVariable("KUBECONFIG", "/root/.kube/config").
-		WithExec(
+		With(CacheBustingExec(
 			[]string{
 				"kubectl", "get", "pods",
-			})
+			}))
 
 	out, err = ctr.Stdout(ctx)
 	if err != nil {
@@ -265,10 +265,10 @@ spec:
 	ctr = dag.Container().From("bitnami/kubectl:latest").
 		WithFile("/root/.kube/config", kubeconfigSource.File("/kubeconfig")).
 		WithEnvVariable("KUBECONFIG", "/root/.kube/config").
-		WithExec(
+		With(CacheBustingExec(
 			[]string{
 				"kubectl", "get", "pods", "-n", "default",
-			})
+			}))
 	out, err = ctr.Stdout(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get pods: %w", err)

--- a/dagger/util.go
+++ b/dagger/util.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"dagger/replicated-sdk/internal/dagger"
+	"time"
+)
+
+// CacheBustingExec is a helper function that will add a cache busting env var automatically
+// to the container. This is useful when Exec target is a dynamic event acting on an entity outside
+// of the container that you absolutely want to re-run every time.
+//
+// Temporary hack until cache controls are a thing: https://docs.dagger.io/cookbook/#invalidate-cache
+func CacheBustingExec(args []string, opts ...dagger.ContainerWithExecOpts) dagger.WithContainerFunc {
+	return func(c *dagger.Container) *dagger.Container {
+		if c == nil {
+			panic("CacheBustingExec requires a container, but container was nil")
+		}
+		return c.WithEnvVariable("DAGGER_CACHEBUSTER_CBE", time.Now().String()).WithExec(args, opts...)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?

This ensures that our 'kubectl get' command output isn't cached.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

