### PR TITLE
fix: add rbac permissions to read legacy replicated-sdk configmap

### DIFF
--- a/chart/templates/replicated-role.yaml
+++ b/chart/templates/replicated-role.yaml
@@ -22,6 +22,14 @@ rules:
   - 'watch'
 {{ end }}
 - apiGroups:
+    - ''
+  resources:
+    - 'configmaps'
+  verbs:
+    - 'get'
+  resourceNames:
+    - 'replicated-sdk'
+- apiGroups:
   - ''
   resources:
   - 'secrets'

--- a/chart/templates/replicated-role.yaml
+++ b/chart/templates/replicated-role.yaml
@@ -89,6 +89,7 @@ rules:
     - 'get'
   resourceNames:
     - 'replicated-sdk'
+
 {{ if not .Values.statusInformers }}
 # the SDK needs to get the helm chart secret to determine what resources to report
 - apiGroups:

--- a/chart/templates/replicated-role.yaml
+++ b/chart/templates/replicated-role.yaml
@@ -22,14 +22,6 @@ rules:
   - 'watch'
 {{ end }}
 - apiGroups:
-    - ''
-  resources:
-    - 'configmaps'
-  verbs:
-    - 'get'
-  resourceNames:
-    - 'replicated-sdk'
-- apiGroups:
   - ''
   resources:
   - 'secrets'
@@ -88,7 +80,15 @@ rules:
   - "get"
   resourceNames:
   - {{ include "replicated.secretName" . }}
-
+# the legacy replicated-sdk configmap is required when the SDK secret is not found
+- apiGroups:
+    - ''
+  resources:
+    - 'configmaps'
+  verbs:
+    - 'get'
+  resourceNames:
+    - 'replicated-sdk'
 {{ if not .Values.statusInformers }}
 # the SDK needs to get the helm chart secret to determine what resources to report
 - apiGroups:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?
When `minimalRBAC` is set to `true`, the set of RBAC permissions given to the replicated service account does not permit it to read the legacy `replicated-sdk` configmap. The permission error comes up when `replicatedID` or `appID` are not loaded from the config.yaml in the `bootstrap` function, which tries to read the `replicated-sdk` configmap in `GetReplicatedAndAppIDs`.
https://github.com/replicatedhq/replicated-sdk/blob/main/pkg/apiserver/bootstrap.go#L31
https://github.com/replicatedhq/replicated-sdk/blob/main/pkg/util/replicated.go#L49

#### Does this PR introduce a user-facing change?
NONE

