### PR TITLE
Always quote namespaces to avoid null namespace linting warnings

### DIFF
--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -29,7 +29,7 @@ stringData:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
               {{- end }}
-            namespace: {{ include "replicated.namespace" . }}
+            namespace: {{ include "replicated.namespace" . | quote }}
             command: ["curl"]
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/updates"]
             timeout: 5s
@@ -40,7 +40,7 @@ stringData:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
               {{- end }}
-            namespace: {{ include "replicated.namespace" . }}
+            namespace: {{ include "replicated.namespace" . | quote }}
             command: ["curl"]
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/history"]
             timeout: 5s
@@ -51,7 +51,7 @@ stringData:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
               {{- end }}
-            namespace: {{ include "replicated.namespace" . }}
+            namespace: {{ include "replicated.namespace" . | quote }}
             command: ["curl"]
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/app/info"]
             timeout: 5s
@@ -62,7 +62,7 @@ stringData:
               {{- range $k, $v := (include "replicated.labels" . | fromYaml) }}
               - {{ $k }}={{ $v }}
               {{- end }}
-            namespace: {{ include "replicated.namespace" . }}
+            namespace: {{ include "replicated.namespace" . | quote }}
             command: ["curl"]
             args: ["-s", "http://{{ include "replicated.serviceName" . }}.{{ include "replicated.namespace" . }}:3000/api/v1/license/info"]
             timeout: 5s


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?

Wraps a couple of unquoted "replicated.namespace" outputs in quotes, this was causing unavoidable linter warnings in vendor portal.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Resolved vendor-portal linter warnings for replicated-support-bundle.
```

