### PR TITLE
use the same dagger version in both CI and deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
           OP_SERVICE_ACCOUNT: ${{ secrets.OP_SERVICE_ACCOUNT }}
           OP_SERVICE_ACCOUNT_PRODUCTION: ${{ secrets.OP_SERVICE_ACCOUNT_PRODUCTION }}
         with:
-          version: "0.18.6"
+          version: "0.18.14"
           verb: call
           args: publish --progress=plain --op-service-account=env:OP_SERVICE_ACCOUNT --op-service-account-production=env:OP_SERVICE_ACCOUNT_PRODUCTION --dev=false --staging=true --version ${{ github.ref_name }}
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
           OP_SERVICE_ACCOUNT_PRODUCTION: ${{ secrets.OP_SERVICE_ACCOUNT_PRODUCTION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          version: "0.18.6"
+          version: "0.18.14"
           verb: call
           args: publish --progress=plain --op-service-account=env:OP_SERVICE_ACCOUNT --op-service-account-production=env:OP_SERVICE_ACCOUNT_PRODUCTION --dev=false --production=true --version ${{ github.ref_name }} --github-token=env:GITHUB_TOKEN --slsa=true
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT: ${{ secrets.OP_SERVICE_ACCOUNT }}
         with:
+          version: "0.18.14"
           verb: call
           args: validate --progress=plain --op-service-account=env:OP_SERVICE_ACCOUNT
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?

This changes both CI and deploy to use dagger 0.18.14, which is currently specified in our dagger config file.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

