### PR TITLE
do not write support bundle spec in readonly mode

### DIFF
--- a/chart/templates/replicated-supportbundle.yaml
+++ b/chart/templates/replicated-supportbundle.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.readOnlyMode }}
 {{/*
 Renders the Support Bundle secret to be used by replicated
 */}}
@@ -102,3 +103,4 @@ stringData:
               - pass:
                   when: "true"
                   message: Replicated SDK App status is ready.
+{{- end }}

--- a/dagger/e2e.go
+++ b/dagger/e2e.go
@@ -956,13 +956,13 @@ spec:
 		WithEnvVariable("KUBECONFIG", kubeconfigPath).
 		With(CacheBustingExec(
 			[]string{
-				"kubectl", "get", "secret", "replicated-ssl-test-supportbundle", "--ignore-not-found",
+				"kubectl", "get", "secret", "replicated-supportbundle", "--ignore-not-found",
 			}))
 	out, err = ctr.Stdout(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to check support bundle secret: %w", err)
 	}
-	if strings.Contains(out, "replicated-ssl-test-supportbundle") {
+	if strings.Contains(out, "replicated-supportbundle") {
 		return fmt.Errorf("support bundle secret exists in read-only mode, expected it to not be created")
 	}
 	fmt.Println("Verified: support bundle secret not created in read-only mode")

--- a/dagger/e2e.go
+++ b/dagger/e2e.go
@@ -950,6 +950,23 @@ spec:
 	}
 	fmt.Println("Verified: replicated-support-metadata secret not created in read-only mode")
 
+	// Verify the support bundle secret was not created
+	ctr = dag.Container().From("bitnami/kubectl:latest").
+		WithFile(kubeconfigPath, kubeconfigSource.File("/kubeconfig")).
+		WithEnvVariable("KUBECONFIG", kubeconfigPath).
+		With(CacheBustingExec(
+			[]string{
+				"kubectl", "get", "secret", "replicated-ssl-test-supportbundle", "--ignore-not-found",
+			}))
+	out, err = ctr.Stdout(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check support bundle secret: %w", err)
+	}
+	if strings.Contains(out, "replicated-ssl-test-supportbundle") {
+		return fmt.Errorf("support bundle secret exists in read-only mode, expected it to not be created")
+	}
+	fmt.Println("Verified: support bundle secret not created in read-only mode")
+
 	// Verify the SDK is healthy by checking the license info endpoint
 	ctr = dag.Container().From("bitnami/kubectl:latest").
 		WithFile(kubeconfigPath, kubeconfigSource.File("/kubeconfig")).


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
Fixes readonly mode to not write the supportbundle secret at all.
```

docs: https://github.com/replicatedhq/replicated-docs/pull/3979

