### PR TITLE
Build securebuild package and images on tag

### DIFF
--- a/.github/workflows/publish-securebuild.yml
+++ b/.github/workflows/publish-securebuild.yml
@@ -1,0 +1,65 @@
+name: publish-securebuild
+
+on:
+  push:
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to build (e.g. 1.19.6)'
+        required: true
+        type: string
+
+jobs:
+  build-package:
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Set version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install securebuild CLI
+        run: |
+          LATEST_TAG=$(curl -s https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
+          curl -sL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          chmod +x securebuild
+
+      - name: Build package
+        run: |
+          ./securebuild build package \
+            --package-family-name replicated-sdk \
+            --tag ${{ steps.version.outputs.version }} \
+            --api-token "${{ secrets.SECUREBUILD_API_TOKEN }}"
+
+  build-image:
+    needs: build-package
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    if: needs.build-package.result == 'success'
+    strategy:
+      matrix:
+        image-name:
+        - replicated-sdk
+        - replicated-sdk-fips
+    steps:
+      - name: Install securebuild CLI
+        run: |
+          LATEST_TAG=$(curl -s https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
+          curl -sL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          chmod +x securebuild
+
+      - name: Build image
+        run: |
+          ./securebuild build image \
+            --image-name ${{ matrix.image-name }} \
+            --tag ${{ needs.build-package.outputs.version }} \
+            --api-token "${{ secrets.SECUREBUILD_API_TOKEN }}"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?

When a release tag is created, automatically publish the SecureBuild package and images.

- This will run in parallel with normal release process and the errors will be silent until we confirm it works.
- This will not run on pre-release tags because SecureBuild does not support pre-release package versions.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note

```

