### PR TITLE
Address github rate limitting when releasing

### DIFF
--- a/.github/workflows/publish-securebuild.yml
+++ b/.github/workflows/publish-securebuild.yml
@@ -28,9 +28,16 @@ jobs:
           fi
 
       - name: Install securebuild CLI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST_TAG=$(curl -s https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
-          curl -sL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          LATEST_TAG=$(curl -sf -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
+          if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+            echo "::error::Failed to determine latest securebuild release tag"
+            exit 1
+          fi
+          curl -sfL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          file securebuild | grep -q 'ELF' || { echo "::error::Downloaded file is not a valid binary"; cat securebuild; exit 1; }
           chmod +x securebuild
 
       - name: Build package
@@ -52,9 +59,16 @@ jobs:
         - replicated-sdk-fips
     steps:
       - name: Install securebuild CLI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LATEST_TAG=$(curl -s https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
-          curl -sL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          LATEST_TAG=$(curl -sf -H "Authorization: Bearer ${GH_TOKEN}" https://api.github.com/repos/securebuildhq/securebuild/releases/latest | jq -r .tag_name)
+          if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+            echo "::error::Failed to determine latest securebuild release tag"
+            exit 1
+          fi
+          curl -sfL "https://github.com/securebuildhq/securebuild/releases/download/${LATEST_TAG}/securebuild-cli-linux-amd64" -o securebuild
+          file securebuild | grep -q 'ELF' || { echo "::error::Downloaded file is not a valid binary"; cat securebuild; exit 1; }
           chmod +x securebuild
 
       - name: Build image


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

# What does this PR do?

Release workflow can fail due to Github rate limiting. Changes below address this issue.

## Securebuild FIPS Image Build Failure - Fix Summary

### Problem

The `replicated-sdk-fips` matrix job in `publish-securebuild.yml` failed with `./securebuild: line 1: Not: command not found` (exit code 127). The `replicated-sdk` job in the same run succeeded.

### Root Cause

Both matrix jobs run in parallel and each makes an **unauthenticated** GitHub API call to fetch the latest securebuild release tag. With multiple jobs hitting the API simultaneously, one job got rate-limited (unauthenticated calls are capped at ~60 req/hr per IP), causing `jq -r .tag_name` to return `null`. The resulting download URL pointed to a non-existent asset, and `curl -sL` (without the `-f` flag) silently saved the "Not Found" error page as the `securebuild` binary. `chmod +x` succeeded on the text file, but execution failed on the first word ("Not").

### Fix

Updated both "Install securebuild CLI" steps in `.github/workflows/publish-securebuild.yml`:

1. **Authenticated API calls** — use the workflow's `GITHUB_TOKEN` as a Bearer token, raising the rate limit to 5,000 req/hr
2. **`curl -f` flag** — fail on HTTP errors instead of silently saving error responses
3. **Tag validation** — exit with error if `LATEST_TAG` is empty or `null`
4. **Binary validation** — verify the download is an ELF binary with `file` before proceeding, printing contents on failure for debugging

## Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

