### PR TITLE
remove OKE test from Dagger

### DIFF
--- a/dagger/cmx.go
+++ b/dagger/cmx.go
@@ -41,7 +41,6 @@ func listCMXDistributionsAndVersions(
 		"gke":       {},
 		"eks":       {},
 		"openshift": {},
-		"oke":       {},
 	}
 
 	for includedDistribution := range versionsToInclude {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
-->

#### What does this PR do?

Removes OKE from the list of distributions that are tested in CMX.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->
```release-note
NONE
```

