### PR TITLE
Wire deployment pod-spec names to replicated.name helper

### DIFF
--- a/chart/templates/replicated-deployment.yaml
+++ b/chart/templates/replicated-deployment.yaml
@@ -93,7 +93,7 @@ spec:
         {{- include "replicated.podSecurityContext" . | nindent 8 }}
       {{- end }}
       volumes:
-      - name: replicated
+      - name: {{ include "replicated.name" . }}
         secret:
           secretName: {{ include "replicated.secretName" . }}
       {{- if .Values.privateCAConfigmap }}
@@ -118,7 +118,7 @@ spec:
       {{- toYaml .Values.initContainers | nindent 6 }}
       {{- end }}
       containers:
-      - name: replicated
+      - name: {{ include "replicated.name" . }}
         image: {{ include "replicated.containerImage" . }}
         imagePullPolicy: {{ include "replicated.imagePullPolicy" . }}
         {{- if .Values.containerSecurityContext }}
@@ -126,7 +126,7 @@ spec:
           {{- include "replicated.containerSecurityContext" . | nindent 12 }}
         {{- end }}
         volumeMounts:
-        - name: replicated
+        - name: {{ include "replicated.name" . }}
           mountPath: /etc/replicated/config.yaml
           readOnly: true
           subPath: config.yaml


### PR DESCRIPTION
#### What does this PR do?
Points the Deployment's `volumes[].name`, `containers[].name`, and `volumeMounts[].name` fields at the existing `replicated.name` helper instead of the hardcoded literal `replicated`, so `nameOverride`/subchart alias rebrands the pod-spec fields too, not just the Kubernetes object names.

Out of scope (per the linked story): config file path, `REPLICATED_*` env vars, image domain, and other internal-only strings.

Verified via `helm template` with `nameOverride` and as an aliased subchart — volume/container/volumeMount all pick up the override, volume/volumeMount stay matched, `helm lint` passes.

Fixes [sc-139090](https://app.shortcut.com/replicated/story/139090).

#### Does this PR introduce a user-facing change?
```release-note
Fixed the Replicated SDK Helm chart so that setting `nameOverride` (or declaring the chart as an aliased subchart) rebrands the container, volume, and volumeMount names in the rendered Deployment, not just the Kubernetes object names.
```
